### PR TITLE
Create SCCS workflow

### DIFF
--- a/dsc/cli.py
+++ b/dsc/cli.py
@@ -70,7 +70,7 @@ def main(
     workflow = workflow_class(
         collection_handle=collection_handle,
         batch_id=batch_id,
-        email_recipients=tuple(email_recipients.split(",")),
+        email_recipients=email_recipients.split(","),
         s3_bucket=s3_bucket,
         output_queue=output_queue,
     )

--- a/dsc/workflows/__init__.py
+++ b/dsc/workflows/__init__.py
@@ -5,7 +5,7 @@ All primary functions used by CLI are importable from here.
 
 from dsc.workflows.base import Workflow
 from dsc.workflows.base.simple_csv import SimpleCSV
-from dsc.workflows.demo import DemoWorkflow
+from dsc.workflows.demo import Demo
 from dsc.workflows.sccs import SCCS
 
-__all__ = ["SCCS", "DemoWorkflow", "SimpleCSV", "Workflow"]
+__all__ = ["SCCS", "Demo", "SimpleCSV", "Workflow"]

--- a/dsc/workflows/__init__.py
+++ b/dsc/workflows/__init__.py
@@ -6,5 +6,6 @@ All primary functions used by CLI are importable from here.
 from dsc.workflows.base import Workflow
 from dsc.workflows.base.simple_csv import SimpleCSV
 from dsc.workflows.demo import DemoWorkflow
+from dsc.workflows.sccs import SCCS
 
-__all__ = ["DemoWorkflow", "SimpleCSV", "Workflow"]
+__all__ = ["SCCS", "DemoWorkflow", "SimpleCSV", "Workflow"]

--- a/dsc/workflows/base/__init__.py
+++ b/dsc/workflows/base/__init__.py
@@ -259,11 +259,18 @@ class Workflow(ABC):
         A metadata mapping is a dict with the format seen below:
 
         {
-        "dc.contributor": {
-            "source_field_name": "contributor",
-            "language": None,
-            "delimiter": "|",
+            "dc.contributor": {
+                "source_field_name": "contributor",
+                "language": "<language>",
+                "delimiter": "<delimiting character>",
+                "required": true | false
+            }
         }
+
+        When setting up the metadata mapping JSON file, "language" and "delimiter"
+        can be omitted from the file if not applicable. Required fields ("item_identifier"
+        and "title") must be set as required (true); if "required" is not listed as a
+        a config, the field defaults as not required (false).
 
         MUST NOT be overridden by workflow subclasses.
 
@@ -281,8 +288,8 @@ class Workflow(ABC):
                         f"{field_mapping["source_field_name"]}'"
                     )
                 if field_value:
-                    delimiter = field_mapping["delimiter"]
-                    language = field_mapping["language"]
+                    delimiter = field_mapping.get("delimiter")
+                    language = field_mapping.get("language")
                     if delimiter:
                         metadata_entries.extend(
                             [

--- a/dsc/workflows/base/__init__.py
+++ b/dsc/workflows/base/__init__.py
@@ -35,7 +35,7 @@ class Workflow(ABC):
         self,
         collection_handle: str,
         batch_id: str,
-        email_recipients: tuple[str, ...],
+        email_recipients: list[str],
         s3_bucket: str | None = None,
         output_queue: str | None = None,
     ) -> None:

--- a/dsc/workflows/demo.py
+++ b/dsc/workflows/demo.py
@@ -1,7 +1,7 @@
 from dsc.workflows.base.simple_csv import SimpleCSV
 
 
-class DemoWorkflow(SimpleCSV):
+class Demo(SimpleCSV):
 
     workflow_name: str = "demo"
     submission_system: str = "DSpace@MIT"

--- a/dsc/workflows/demo.py
+++ b/dsc/workflows/demo.py
@@ -5,4 +5,4 @@ class DemoWorkflow(SimpleCSV):
 
     workflow_name: str = "demo"
     submission_system: str = "DSpace@MIT"
-    metadata_mapping_path: str = "tests/fixtures/demo_metadata_mapping.json"
+    metadata_mapping_path: str = "dsc/workflows/metadata_mapping/demo.json"

--- a/dsc/workflows/metadata_mapping/demo.json
+++ b/dsc/workflows/metadata_mapping/demo.json
@@ -1,35 +1,28 @@
 {
     "item_identifier": {
         "source_field_name": "item_identifier",
-        "language": null,
-        "delimiter": "",
         "required": true
     },
     "dc.title": {
         "source_field_name": "dc.title",
         "language": "en_US",
-        "delimiter": "",
         "required": true
     },
     "dc.publisher": {
         "source_field_name": "dc.publisher",
-        "language": "en_US",
-        "delimiter": ""
+        "language": "en_US"
     },
     "dc.eprint.version": {
         "source_field_name": "dc.eprint.version",
-        "language": "en_US",
-        "delimiter": ""
+        "language": "en_US"
     },
     "dc.type": {
         "source_field_name": "dc.type",
-        "language": "en_US",
-        "delimiter": ""
+        "language": "en_US"
     },
     "dc.source": {
         "source_field_name": "dc.source",
-        "language": "en_US",
-        "delimiter": ""
+        "language": "en_US"
     },
     "dc.contributor.author": {
         "source_field_name": "dc.contributor.author",
@@ -37,28 +30,18 @@
         "delimiter": "|"
     },
     "dc.relation.isversionof": {
-        "source_field_name": "dc.relation.isversionof",
-        "language": "",
-        "delimiter": ""
+        "source_field_name": "dc.relation.isversionof"
     },
     "dc.relation.journal": {
-        "source_field_name": "dc.relation.journal",
-        "language": "",
-        "delimiter": ""
+        "source_field_name": "dc.relation.journal"
     },
     "dc.identifier.issn": {
-        "source_field_name": "dc.identifier.issn",
-        "language": "",
-        "delimiter": ""
+        "source_field_name": "dc.identifier.issn"
     },
     "dc.date.issued": {
-        "source_field_name": "dc.date.issued",
-        "language": "",
-        "delimiter": ""
+        "source_field_name": "dc.date.issued"
     },
     "dc.rights.uri": {
-        "source_field_name": "dc.rights.uri",
-        "language": "",
-        "delimiter": ""
+        "source_field_name": "dc.rights.uri"
     }
 }

--- a/dsc/workflows/metadata_mapping/demo.json
+++ b/dsc/workflows/metadata_mapping/demo.json
@@ -2,7 +2,14 @@
     "item_identifier": {
         "source_field_name": "item_identifier",
         "language": null,
-        "delimiter": ""
+        "delimiter": "",
+        "required": true
+    },
+    "dc.title": {
+        "source_field_name": "dc.title",
+        "language": "en_US",
+        "delimiter": "",
+        "required": true
     },
     "dc.publisher": {
         "source_field_name": "dc.publisher",
@@ -32,11 +39,6 @@
     "dc.relation.isversionof": {
         "source_field_name": "dc.relation.isversionof",
         "language": "",
-        "delimiter": ""
-    },
-    "dc.title": {
-        "source_field_name": "dc.title",
-        "language": "en_US",
         "delimiter": ""
     },
     "dc.relation.journal": {

--- a/dsc/workflows/metadata_mapping/sccs.json
+++ b/dsc/workflows/metadata_mapping/sccs.json
@@ -1,0 +1,79 @@
+{
+    "item_identifier": {
+        "source_field_name": "item_identifier",
+        "language": null,
+        "delimiter": "",
+        "required": true
+    },
+    "dc.title": {
+        "source_field_name": "dc.title",
+        "language": "en_US",
+        "delimiter": "",
+        "required": true
+    },
+    "dc.publisher": {
+        "source_field_name": "dc.publisher",
+        "language": "en_US",
+        "delimiter": ""
+    },
+    "dc.identifier.mitlicense": {
+        "source_field_name": "dc.identifier.mitlicense",
+        "language": "en_US",
+        "delimiter": ""
+    },
+    "dc.eprint.version": {
+        "source_field_name": "dc.eprint.version",
+        "language": "en_US",
+        "delimiter": ""
+    },
+    "dc.type": {
+        "source_field_name": "dc.type",
+        "language": "en_US",
+        "delimiter": ""
+    },
+    "dc.source": {
+        "source_field_name": "dc.source",
+        "language": "en_US",
+        "delimiter": ""
+    },
+    "dc.contributor.author": {
+        "source_field_name": "dc.contributor.author",
+        "language": "en_US",
+        "delimiter": "|"
+    },
+    "dc.relation.isversionof": {
+        "source_field_name": "dc.relation.isversionof",
+        "language": "",
+        "delimiter": ""
+    },
+    "dc.relation.journal": {
+        "source_field_name": "dc.relation.journal",
+        "language": "",
+        "delimiter": ""
+    },
+    "dc.identifier.issn": {
+        "source_field_name": "dc.identifier.issn",
+        "language": "",
+        "delimiter": ""
+    },
+    "dc.date.issued": {
+        "source_field_name": "dc.date.issued",
+        "language": "",
+        "delimiter": ""
+    },
+    "dc.rights": {
+        "source_field_name": "dc.rights",
+        "language": "en_US",
+        "delimiter": ""
+    },
+    "dc.rights.uri": {
+        "source_field_name": "dc.rights.uri",
+        "language": "",
+        "delimiter": ""
+    },
+    "dc.description.sponsorship": {
+        "source_field_name": "dc.description.sponsorship",
+        "language": "en_US",
+        "delimiter": ""
+    }
+}

--- a/dsc/workflows/metadata_mapping/sccs.json
+++ b/dsc/workflows/metadata_mapping/sccs.json
@@ -1,40 +1,32 @@
 {
     "item_identifier": {
         "source_field_name": "item_identifier",
-        "language": null,
-        "delimiter": "",
         "required": true
     },
     "dc.title": {
         "source_field_name": "dc.title",
         "language": "en_US",
-        "delimiter": "",
         "required": true
     },
     "dc.publisher": {
         "source_field_name": "dc.publisher",
-        "language": "en_US",
-        "delimiter": ""
+        "language": "en_US"
     },
     "dc.identifier.mitlicense": {
         "source_field_name": "dc.identifier.mitlicense",
-        "language": "en_US",
-        "delimiter": ""
+        "language": "en_US"
     },
     "dc.eprint.version": {
         "source_field_name": "dc.eprint.version",
-        "language": "en_US",
-        "delimiter": ""
+        "language": "en_US"
     },
     "dc.type": {
         "source_field_name": "dc.type",
-        "language": "en_US",
-        "delimiter": ""
+        "language": "en_US"
     },
     "dc.source": {
         "source_field_name": "dc.source",
-        "language": "en_US",
-        "delimiter": ""
+        "language": "en_US"
     },
     "dc.contributor.author": {
         "source_field_name": "dc.contributor.author",
@@ -42,38 +34,26 @@
         "delimiter": "|"
     },
     "dc.relation.isversionof": {
-        "source_field_name": "dc.relation.isversionof",
-        "language": "",
-        "delimiter": ""
+        "source_field_name": "dc.relation.isversionof"
     },
     "dc.relation.journal": {
-        "source_field_name": "dc.relation.journal",
-        "language": "",
-        "delimiter": ""
+        "source_field_name": "dc.relation.journal"
     },
     "dc.identifier.issn": {
-        "source_field_name": "dc.identifier.issn",
-        "language": "",
-        "delimiter": ""
+        "source_field_name": "dc.identifier.issn"
     },
     "dc.date.issued": {
-        "source_field_name": "dc.date.issued",
-        "language": "",
-        "delimiter": ""
+        "source_field_name": "dc.date.issued"
     },
     "dc.rights": {
         "source_field_name": "dc.rights",
-        "language": "en_US",
-        "delimiter": ""
+        "language": "en_US"
     },
     "dc.rights.uri": {
-        "source_field_name": "dc.rights.uri",
-        "language": "",
-        "delimiter": ""
+        "source_field_name": "dc.rights.uri"
     },
     "dc.description.sponsorship": {
         "source_field_name": "dc.description.sponsorship",
-        "language": "en_US",
-        "delimiter": ""
+        "language": "en_US"
     }
 }

--- a/dsc/workflows/sccs.py
+++ b/dsc/workflows/sccs.py
@@ -1,0 +1,13 @@
+from dsc.workflows import SimpleCSV
+
+
+class SCCS(SimpleCSV):
+    """Workflow for SCCS-requested deposits.
+
+    The deposits managed by this workflow are requested by the Scholarly
+    Communication and Collection Strategy (SCCS) department
+    and are for submission to DSpace@MIT.
+    """
+
+    workflow_name: str = "sccs"
+    metadata_mapping_path: str = "dsc/workflows/metadata_mapping/sccs.json"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,6 @@ class TestWorkflow(Workflow):
 
     workflow_name: str = "test"
     submission_system: str = "Test@MIT"
-    email_recipients: tuple[str] = ("test@test.test",)
     metadata_mapping_path: str = "tests/fixtures/test_metadata_mapping.json"
 
     def item_metadata_iter(self):
@@ -56,10 +55,7 @@ class TestSimpleCSV(SimpleCSV):
 
     workflow_name = "simple_csv"
     submission_system: str = "Test@MIT"
-    email_recipients: tuple[str] = ("test@test.test",)
     metadata_mapping_path: str = "tests/fixtures/test_metadata_mapping.json"
-    s3_bucket: str = "dsc"
-    output_queue: str = "mock-output_queue"
 
 
 @pytest.fixture(autouse=True)
@@ -79,6 +75,7 @@ def base_workflow_instance(item_metadata, metadata_mapping, mocked_s3):
         collection_handle="123.4/5678",
         batch_id="batch-aaa",
         email_recipients=["test@test.test"],
+        output_queue="mock-output_queue",
     )
 
 
@@ -88,6 +85,7 @@ def simple_csv_workflow_instance(metadata_mapping):
         collection_handle="123.4/5678",
         batch_id="batch-aaa",
         email_recipients=["test@test.test"],
+        output_queue="mock-output_queue",
     )
 
 

--- a/tests/fixtures/test_metadata_mapping.json
+++ b/tests/fixtures/test_metadata_mapping.json
@@ -1,19 +1,15 @@
 {
     "item_identifier": {
         "source_field_name": "item_identifier",
-        "language": null,
-        "delimiter": "",
         "required": true
     },
     "dc.title": {
         "source_field_name": "title",
         "language": "en_US",
-        "delimiter": "",
         "required": true
     },
     "dc.contributor": {
         "source_field_name": "contributor",
-        "language": null,
         "delimiter": "|"
     }
 }


### PR DESCRIPTION
### Purpose and background context

This PR creates the `SCCS` DSC workflow. [Implementation of the `SCCS` workflow](https://github.com/MITLibraries/dspace-submission-composer/pull/77/files#diff-e07a5d9e3ef8937e0db21e1ef4145c6f4077a98b765a13f5492f017514d088df) was amazingly simple as it inherits from the `SimpleCSV` base workflow and only required assigning values for the `workflow_name` and `metadata_mapping_path` class attributes. This also introduces [a new folder in `dsc/workflows` to hold metadata mapping JSON](https://github.com/MITLibraries/dspace-submission-composer/tree/IN-1098-sccs-workflow/dsc/workflows/metadata_mapping) files. 
* `demo.json` (formerly `demo_metadata_mapping.json`) was moved from the `tests/fixtures` folder.
* `sccs.json` is an updated version of [the metadata mapping JSON file from `dspace-api-python-scripts`](https://github.com/MITLibraries/dspace-api-python-scripts/blob/s3/config/dspacemit.json)

This PR also includes additional changes for cleanup: 
* Renaming `DemoWorkflow` -> `Demo`
* Changing `email_recipients` to `list[str]`
   **Note:** @ehanson8 , `mypy` may have been throwing an error previously if it was assigned an empty list (`[]`) (a "mutable default") in the `__init__` signature. 🤔 
* Cleaning up `TestWorkflow` and `TestSimpleCSV` fixtures
   * Pass values for `email_recipients` and `output_queue` when creating instances (i.e., `base_workflow_instance` and `simple_csv_workflow_instance` fixtures)

### How can a reviewer manually see the effects of these changes?
Run `make lint` and `make test` and verify all unit tests are passing. 

@ehanson8 and I synced up to discuss testing and whether new unit tests were required for the creation of the `SCCS` workflow. In summary:
* A `test_<workflow>.py` module should only be created to test functionality of **overridden** methods.
* Metadata mapping is covered by [these unit tests](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1098-sccs-workflow/tests/test_workflow.py#L195-L214). Regarding metadata mapping, these tests confirm:
   * Source field names -> Dublin Core field mappings is successful
   * Presence of delimiters results in entries created for each value in a delimiter-separated string
   * An error is raised when a field with `"required": true` is missing.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1098

### Developer
- [X] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

