### PR TITLE
Refactor approach for reconciling bitstreams and metadata

### DIFF
--- a/dsc/cli.py
+++ b/dsc/cli.py
@@ -5,6 +5,7 @@ from time import perf_counter
 import click
 
 from dsc.config import Config
+from dsc.exceptions import ReconcileError
 from dsc.workflows.base import Workflow
 
 logger = logging.getLogger(__name__)
@@ -105,7 +106,11 @@ def post_main_group_subcommand(
 def reconcile(ctx: click.Context) -> None:
     """Reconcile bitstreams with item identifiers from the metadata."""
     workflow = ctx.obj["workflow"]
-    workflow.reconcile_bitstreams_and_metadata()
+    try:
+        workflow.reconcile_bitstreams_and_metadata()
+    except ReconcileError:
+        logger.info("Reconcile failed.")
+        ctx.exit(1)
 
 
 @main.command()

--- a/dsc/cli.py
+++ b/dsc/cli.py
@@ -105,16 +105,7 @@ def post_main_group_subcommand(
 def reconcile(ctx: click.Context) -> None:
     """Reconcile bitstreams with item identifiers from the metadata."""
     workflow = ctx.obj["workflow"]
-    no_bitstreams, no_item_identifiers = workflow.reconcile_bitstreams_and_metadata()
-
-    if no_bitstreams:
-        logger.error(f"No bitstreams found for these item identifiers: {no_bitstreams}")
-    if no_item_identifiers:
-        logger.error(
-            f"No item identifiers found for these bitstreams: {no_item_identifiers}"
-        )
-    else:
-        logger.info("All item identifiers and bitstreams successfully matched")
+    workflow.reconcile_bitstreams_and_metadata()
 
 
 @main.command()

--- a/dsc/exceptions.py
+++ b/dsc/exceptions.py
@@ -12,3 +12,7 @@ class InvalidWorkflowNameError(Exception):
 
 class ItemMetadatMissingRequiredFieldError(Exception):
     pass
+
+
+class ReconcileError(Exception):
+    pass

--- a/dsc/workflows/base/__init__.py
+++ b/dsc/workflows/base/__init__.py
@@ -96,15 +96,10 @@ class Workflow(ABC):
         """Reconcile bitstreams against metadata.
 
         Items in DSpace represent a "work" and combine metadata and files,
-        known as "bitstreams". For any given workflow, the purpose of this
-        method is to determine whether sufficient data has been provided
-        for a batch of items to be submitted into DSpace, but how this
-        method accomplishes this varies based on the data provided
-        to execute the workflow.
-
-        This method ensures the existence of both bitstreams and metadata
-        for each item in the batch, verifying that all provided bitstreams
-        can be linked to a metadata record and vice versa.
+        known as "bitstreams". For any given workflow, this method ensures
+        the existence of both bitstreams and metadata for each item in the
+        batch, verifying that all provided bitstreams can be linked to a
+        metadata record and vice versa.
 
         While this method is not needed for every workflow,
         it MUST be overridden by all workflow subclasses.
@@ -112,9 +107,10 @@ class Workflow(ABC):
         raise the following exception:
 
         TypeError(
-            f"Method {self.reconcile_bitstreams_and_metadata.__name__} not used by workflow."
+            f"Method '{self.reconcile_bitstreams_and_metadata.__name__}' "
+            f"not used by workflow '{self.__class__.__name__}'."
         )
-        """  # noqa: E501, W505
+        """
 
     @final
     def submit_items(self) -> dict:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,11 @@ class TestWorkflow(Workflow):
     submission_system: str = "Test@MIT"
     metadata_mapping_path: str = "tests/fixtures/test_metadata_mapping.json"
 
+    def reconcile_bitstreams_and_metadata(self):
+        raise TypeError(
+            f"Method {self.reconcile_bitstreams_and_metadata.__name__} not used by workflow."  # noqa: E501
+        )
+
     def item_metadata_iter(self):
         yield from [
             {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,8 @@ class TestWorkflow(Workflow):
 
     def reconcile_bitstreams_and_metadata(self):
         raise TypeError(
-            f"Method {self.reconcile_bitstreams_and_metadata.__name__} not used by workflow."  # noqa: E501
+            f"Method '{self.reconcile_bitstreams_and_metadata.__name__}' "
+            f"not used by workflow '{self.__class__.__name__}'"
         )
 
     def item_metadata_iter(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 from dsc.cli import main
-from dsc.exceptions import ReconcileError
 
 
 @patch("dsc.utilities.aws.s3.S3Client.files_iter")
@@ -63,7 +62,6 @@ def test_reconcile_simple_csv_if_no_metadata_raise_error(
         ],
     )
     assert result.exit_code == 1
-    assert isinstance(result.exception, ReconcileError)
     assert "Failed to reconcile bitstreams and metadata" in caplog.text
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,75 @@
+from unittest.mock import patch
+
 from dsc.cli import main
+from dsc.exceptions import ReconcileError
 
 
-def test_reconcile_success(caplog, runner, mocked_s3, base_workflow_instance, s3_client):
-    s3_client.put_file(file_content="", bucket="dsc", key="test/batch-aaa/123_01.pdf")
-    s3_client.put_file(file_content="", bucket="dsc", key="test/batch-aaa/123_02.jpg")
-    s3_client.put_file(file_content="", bucket="dsc", key="test/batch-aaa/789_01.pdf")
+@patch("dsc.utilities.aws.s3.S3Client.files_iter")
+def test_reconcile_simple_csv_success(
+    mock_s3_client_files_iter,
+    caplog,
+    runner,
+    simple_csv_workflow_instance,
+    mocked_s3_simple_csv,
+):
+    mock_s3_client_files_iter.return_value = [
+        "s3://dsc/simple_csv/batch-aaa/123_001.pdf",
+        "s3://dsc/simple_csv/batch-aaa/123_002.pdf",
+    ]
+    result = runner.invoke(
+        main,
+        [
+            "--workflow-name",
+            "simple_csv",
+            "--collection-handle",
+            "123.4/5678",
+            "--batch-id",
+            "batch-aaa",
+            "--email-recipients",
+            "test@test.test",
+            "reconcile",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Successfully reconciled bitstreams and metadata for all items" in caplog.text
+    assert "Total time elapsed" in caplog.text
+
+
+@patch("dsc.utilities.aws.s3.S3Client.files_iter")
+def test_reconcile_simple_csv_if_no_metadata_raise_error(
+    mock_s3_client_files_iter,
+    caplog,
+    runner,
+    simple_csv_workflow_instance,
+    mocked_s3_simple_csv,
+):
+    mock_s3_client_files_iter.return_value = [
+        "s3://dsc/simple_csv/batch-aaa/123_001.pdf",
+        "s3://dsc/simple_csv/batch-aaa/123_002.pdf",
+        "s3://dsc/simple_csv/batch-aaa/124_001.pdf",
+    ]
+    result = runner.invoke(
+        main,
+        [
+            "--workflow-name",
+            "simple_csv",
+            "--collection-handle",
+            "123.4/5678",
+            "--batch-id",
+            "batch-aaa",
+            "--email-recipients",
+            "test@test.test",
+            "reconcile",
+        ],
+    )
+    assert result.exit_code == 1
+    assert isinstance(result.exception, ReconcileError)
+    assert "Failed to reconcile bitstreams and metadata" in caplog.text
+
+
+def test_reconcile_if_non_reconcile_workflow_raise_error(
+    caplog, runner, base_workflow_instance
+):
     result = runner.invoke(
         main,
         [
@@ -19,43 +84,8 @@ def test_reconcile_success(caplog, runner, mocked_s3, base_workflow_instance, s3
             "reconcile",
         ],
     )
-    assert result.exit_code == 0
-    assert (
-        "Item identifiers from batch metadata with matching bitstreams: ['123', '789']"
-        in caplog.text
-    )
-    assert "All item identifiers and bitstreams successfully matched" in caplog.text
-    assert "Total time elapsed" in caplog.text
-
-
-def test_reconcile_discrepancies_logged(
-    caplog, runner, mocked_s3, base_workflow_instance, s3_client
-):
-    s3_client.put_file(file_content="", bucket="dsc", key="test/batch-aaa/123_01.pdf")
-    s3_client.put_file(file_content="", bucket="dsc", key="test/batch-aaa/123_02.jpg")
-    s3_client.put_file(file_content="", bucket="dsc", key="test/batch-aaa/456_01.pdf")
-    result = runner.invoke(
-        main,
-        [
-            "--workflow-name",
-            "test",
-            "--collection-handle",
-            "123.4/5678",
-            "--batch-id",
-            "batch-aaa",
-            "--email-recipients",
-            "test@test.edu",
-            "reconcile",
-        ],
-    )
-    assert result.exit_code == 0
-    assert (
-        "Item identifiers from batch metadata with matching bitstreams: ['123']"
-        in caplog.text
-    )
-    assert "No bitstreams found for these item identifiers: {'789'}" in caplog.text
-    assert "No item identifiers found for these bitstreams: {'456'}" in caplog.text
-    assert "Total time elapsed" in caplog.text
+    assert result.exit_code == 1
+    assert isinstance(result.exception, TypeError)
 
 
 def test_submit_success(

--- a/tests/test_simple_csv_workflow.py
+++ b/tests/test_simple_csv_workflow.py
@@ -1,4 +1,5 @@
 # ruff: noqa: SLF001
+import json
 from unittest.mock import patch
 
 import pytest
@@ -35,14 +36,21 @@ def test_simple_csv_workflow_reconcile_bitstreams_and_metadata_if_no_metadata_ra
         "s3://dsc/simple_csv/batch-aaa/123_002.pdf",
         "s3://dsc/simple_csv/batch-aaa/124_001.pdf",
     ]
+    expected_reconcile_error_message = {
+        "note": "Failed to reconcile bitstreams and metadata.",
+        "bitstreams_without_metadata": {
+            "count": 1,
+            "identifiers": ["124"],
+        },
+        "metadata_without_bitstreams": {
+            "count": 0,
+            "identifiers": [],
+        },
+    }
     with pytest.raises(ReconcileError):
         simple_csv_workflow_instance.reconcile_bitstreams_and_metadata()
 
-    assert (
-        "Failed to reconcile bitstreams and metadata. "
-        'Bitstreams without metadata (n=1): ["124"]. '
-        "Metadata without bitstreams (n=0): []."
-    ) in caplog.text
+    assert json.dumps(expected_reconcile_error_message) in caplog.text
 
 
 @patch("dsc.utilities.aws.s3.S3Client.files_iter")

--- a/tests/test_simple_csv_workflow.py
+++ b/tests/test_simple_csv_workflow.py
@@ -1,4 +1,69 @@
+# ruff: noqa: SLF001
 from unittest.mock import patch
+
+import pytest
+
+from dsc.exceptions import ReconcileError
+
+
+@patch("dsc.utilities.aws.s3.S3Client.files_iter")
+def test_simple_csv_workflow_reconcile_bitstreams_and_metadata_success(
+    mock_s3_client_files_iter,
+    caplog,
+    simple_csv_workflow_instance,
+    mocked_s3_simple_csv,
+):
+    mock_s3_client_files_iter.return_value = [
+        "s3://dsc/simple_csv/batch-aaa/123_001.pdf",
+        "s3://dsc/simple_csv/batch-aaa/123_002.pdf",
+    ]
+    simple_csv_workflow_instance.reconcile_bitstreams_and_metadata()
+    assert (
+        "Successfully reconciled bitstreams and metadata for all items (n=1)"
+    ) in caplog.text
+
+
+@patch("dsc.utilities.aws.s3.S3Client.files_iter")
+def test_simple_csv_workflow_reconcile_bitstreams_and_metadata_if_no_metadata_raise_error(
+    mock_s3_client_files_iter,
+    caplog,
+    simple_csv_workflow_instance,
+    mocked_s3_simple_csv,
+):
+    mock_s3_client_files_iter.return_value = [
+        "s3://dsc/simple_csv/batch-aaa/123_001.pdf",
+        "s3://dsc/simple_csv/batch-aaa/123_002.pdf",
+        "s3://dsc/simple_csv/batch-aaa/124_001.pdf",
+    ]
+    with pytest.raises(ReconcileError):
+        simple_csv_workflow_instance.reconcile_bitstreams_and_metadata()
+
+    assert (
+        "Failed to reconcile bitstreams and metadata. "
+        'Bitstreams without metadata (n=1): ["124"]. '
+        "Metadata without bitstreams (n=0): []."
+    ) in caplog.text
+
+
+@patch("dsc.utilities.aws.s3.S3Client.files_iter")
+def test_simple_csv_workflow_get_item_identifiers_from_bitstreams_success(
+    mock_s3_client_files_iter, simple_csv_workflow_instance
+):
+    mock_s3_client_files_iter.return_value = [
+        "s3://dsc/simple_csv/batch-aaa/123_001.pdf",
+        "s3://dsc/simple_csv/batch-aaa/123_002.pdf",
+        "s3://dsc/simple_csv/batch-aaa/124_001.pdf",
+    ]
+    assert simple_csv_workflow_instance._get_item_identifiers_from_bitstreams() == {
+        "123",
+        "124",
+    }
+
+
+def test_simple_csv_workflow_get_item_identifiers_from_metadata_success(
+    simple_csv_workflow_instance, mocked_s3_simple_csv
+):
+    assert simple_csv_workflow_instance._get_item_identifiers_from_metadata() == {"123"}
 
 
 def test_simple_csv_workflow_item_metadata_iter_success(

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -65,56 +65,11 @@ def test_base_workflow_get_workflow_invalid_workflow_name_raises_error(
         base_workflow_instance.get_workflow("tast")
 
 
-def test_base_workflow_reconcile_bitstreams_and_metadata_success(
-    caplog, base_workflow_instance, mocked_s3, s3_client
+def test_base_workflow_reconcile_bitstreams_and_metadata_if_non_reconcile_raises_error(
+    base_workflow_instance,
 ):
-    s3_client.put_file(file_content="", bucket="dsc", key="test/batch-aaa/123_01.pdf")
-    s3_client.put_file(file_content="", bucket="dsc", key="test/batch-aaa/123_02.jpg")
-    s3_client.put_file(file_content="", bucket="dsc", key="test/batch-aaa/456_01.pdf")
-    assert base_workflow_instance.reconcile_bitstreams_and_metadata() == (
-        {"789"},
-        {"456"},
-    )
-    assert (
-        "Item identifiers from batch metadata with matching bitstreams: ['123']"
-        in caplog.text
-    )
-
-
-def test_build_bitstream_dict_success(mocked_s3, s3_client, base_workflow_instance):
-    s3_client.put_file(file_content="", bucket="dsc", key="test/batch-aaa/123_01.pdf")
-    s3_client.put_file(file_content="", bucket="dsc", key="test/batch-aaa/123_02.pdf")
-    s3_client.put_file(file_content="", bucket="dsc", key="test/batch-aaa/456_01.pdf")
-    s3_client.put_file(file_content="", bucket="dsc", key="test/batch-aaa/789_01.jpg")
-    assert base_workflow_instance._build_bitstream_dict() == {  # noqa: SLF001
-        "123": ["test/batch-aaa/123_01.pdf", "test/batch-aaa/123_02.pdf"],
-        "456": ["test/batch-aaa/456_01.pdf"],
-        "789": ["test/batch-aaa/789_01.jpg"],
-    }
-
-
-def test_match_item_identifiers_to_bitstreams_success(base_workflow_instance):
-    bitstream_dict = {"test": "test_01.pdf"}
-    item_identifiers = ["test", "tast"]
-    item_identifier_matches = (
-        base_workflow_instance._match_item_identifiers_to_bitstreams(  # noqa: SLF001
-            bitstream_dict.keys(), item_identifiers
-        )
-    )
-    assert len(item_identifier_matches) == 1
-    assert "test" in item_identifier_matches
-
-
-def test_match_bitstreams_to_item_identifiers_success(base_workflow_instance):
-    bitstream_dict = {"test": "test_01.pdf", "tast": "tast_01.pdf"}
-    item_identifiers = ["test"]
-    file_matches = (
-        base_workflow_instance._match_bitstreams_to_item_identifiers(  # noqa: SLF001
-            bitstream_dict, item_identifiers
-        )
-    )
-    assert len(file_matches) == 1
-    assert "test" in file_matches
+    with pytest.raises(TypeError):
+        base_workflow_instance.reconcile_bitstreams_and_metadata()
 
 
 def test_base_workflow_submit_items_success(

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -68,7 +68,12 @@ def test_base_workflow_get_workflow_invalid_workflow_name_raises_error(
 def test_base_workflow_reconcile_bitstreams_and_metadata_if_non_reconcile_raises_error(
     base_workflow_instance,
 ):
-    with pytest.raises(TypeError):
+    with pytest.raises(
+        TypeError,
+        match=(
+            "Method 'reconcile_bitstreams_and_metadata' not used by workflow 'TestWorkflow'"  # noqa: E501
+        ),
+    ):
         base_workflow_instance.reconcile_bitstreams_and_metadata()
 
 


### PR DESCRIPTION
### Purpose and background context

This PR aims to address the concerns outlined in https://github.com/MITLibraries/dspace-submission-composer/issues/102. Namely,

* **Not all workflows require a `reconcile()` method.**
* Related to above, the `reconcile` methods in the base `Workflow` class were highly opinionated towards the `SimpleCSV` workflow, making it difficult to apply the logic + terms  for the implementation of other workflows (e.g., `OpenCourseWare` and `Wiley`).

This PR includes the following changes:

* [Make `Workflow.reconcile_bitstreams_and_metadata` an abstract method](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1158-revise-reconcile-method/dsc/workflows/base/__init__.py#L94-L117).
   * **Why is it an abstract method if it doesn't need to be implemented for a workflow?**: This is require a developer to define a method to explicitly indicate whether or not a `reconcile` method is applicable. As noted in the docstring, if not applicable, the method should simply raise the recommended `TypeError`. 
* [Move and refactor `reconcile` method for `SimpleCSV` workflows](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1158-revise-reconcile-method/dsc/workflows/base/simple_csv.py#L24-L94).
   * As noted in the linked issue, previously used terms and private methods made it a bit difficult to follow the set methods to identify "bitstreams without metadata" and "metadata without bitstreams".  
   * The goal is that the changes clarify the following: 
      * "item identifiers": Unique identifiers for an item submission. For `SimpleCSV`, these values can be extracted from the metadata file (the CSV file) and the bitstream filenames.
      * "matching item identifiers": Unique identifiers for an item submission with both bitstreams and metadata.
      * "bitstreams without metadata": Unique identifiers for item submissions with only bitstreams, derived by taking: `(set of all item IDs extracted from bitstreams) - (set of matching item identifiers)` 
      * "metadata without bitstreams": Unique identifiers for item submissions with only metadata, derived by taking: `(set of all item IDs extracted from metadata) - (set of matching item identifiers)` 
   * [A `ReconcileError` is raised if any discrepancies are found](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1158-revise-reconcile-method/dsc/workflows/base/simple_csv.py#L57-L58).
* [Simplify `reconcile` CLI command to simply call workflow's implementation of `reconcile_bitstreams_and_metadata` method](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1158-revise-reconcile-method/dsc/cli.py#L103-L108).

### How can a reviewer manually see the effects of these changes?

**A. Review the added unit tests.**
1. [Revised the `base_workflow_instance` fixture to demonstrate non-reconcile workflow](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1158-revise-reconcile-method/tests/conftest.py#L19-L28)
   * [Demonstrate raise of `TypeError` exception for non-reconcile](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1158-revise-reconcile-method/tests/test_workflow.py#L68-L72)
2. [`SimpleCSV` reconcile unit tests](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1158-revise-reconcile-method/tests/test_simple_csv_workflow.py#L9-L45)
3. [Verifying `reconcile` CLI command logs expected message and returns expected exit code](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1158-revise-reconcile-method/tests/test_cli.py#L7-L88)

**B. Optional but highly recommended.**
Run `reconcile` CLI commands **using local MinIO server**.

**Prerequisite**
1. Follow instructions in README: [Running a Local MinIO Server](https://github.com/MITLibraries/dspace-submission-composer?tab=readme-ov-file#running-a-local-minio-server).
   Note: As of this writing, the root password set for the local MinIO server **must be at least 8 characters long**. Didn't want to write this requirement in the README as it is subject to change if/when we download updated versions of the MinIO Docker image.
5. Mock out the local MinIO server with test zip files. 
   Note: I did these steps via the WebUI. 
   * Create paths (i.e., prefix) in the `dsc` bucket: 
      * `dsc/sccs/batch-00` (depicts successful reconcile):
         * Upload [metadata.csv](https://github.com/user-attachments/files/18608310/metadata.csv)
        * Upload the following files: 
          [D3DD00227F.pdf](https://github.com/user-attachments/files/18608314/D3DD00227F.pdf)
          [D3MA00799E.pdf](https://github.com/user-attachments/files/18608315/D3MA00799E.pdf)
          [D3MH01277H.pdf](https://github.com/user-attachments/files/18608316/D3MH01277H.pdf)
          [D3SC05353A.pdf](https://github.com/user-attachments/files/18608317/D3SC05353A.pdf)
      * `dsc/sccs/batch-01` (depicts item metadata without bitstreams): 
         * Upload [metadata.csv](https://github.com/user-attachments/files/18608310/metadata.csv)
      

6. Add the following environment variables in your `.env` file.
   ```text
   AWS_ENDPOINT_URL=http://localhost:9000/
   AWS_ACCESS_KEY_ID=<local-minio-username>
   AWS_SECRET_ACCESS_KEY=<local-minio-password>
   ```

**Invoke `reconcile` CLI commands**

1. Run reconcile for `sccs/batch-00`

```shell
pipenv run dsc -w "sccs" -c "abc123" -b "batch-00" -e "me@gmail.com" reconcile       
```

You should see the following output:

```shell
Loading .env environment variables...
Courtesy Notice: Pipenv found itself running within a virtual environment, so it will automatically use that environment, instead of creating its own for any project. You can set PIPENV_IGNORE_VIRTUALENVS=1 to force pipenv to ignore that environment and create its own instead. You can set PIPENV_VERBOSITY=-1 to suppress this warning.
2025-01-31 08:59:45,588 INFO root.configure_logger(): INFO
2025-01-31 08:59:45,588 INFO dsc.cli.main(): Logger 'root' configured with level=INFO
2025-01-31 08:59:45,588 INFO dsc.cli.main(): No Sentry DSN found, exceptions will not be sent to Sentry
2025-01-31 08:59:45,589 INFO dsc.cli.main(): Running process
2025-01-31 08:59:45,601 INFO botocore.credentials.load(): Found credentials in environment variables.
2025-01-31 08:59:45,733 INFO botocore.configprovider.provide(): Found endpoint for s3 via: environment_global.
2025-01-31 08:59:45,777 INFO botocore.configprovider.provide(): Found endpoint for s3 via: environment_global.
2025-01-31 08:59:45,792 INFO botocore.httpchecksum.handle_checksum_body(): Skipping checksum validation. Response did not contain one of the following algorithms: ['crc32', 'sha1', 'sha256'].
2025-01-31 08:59:45,792 INFO dsc.workflows.base.simple_csv.reconcile_bitstreams_and_metadata(): Successfully reconciled bitstreams and metadata for all items (n=4).
2025-01-31 08:59:45,792 INFO dsc.cli.post_main_group_subcommand(): Application exiting
2025-01-31 08:59:45,793 INFO dsc.cli.post_main_group_subcommand(): Total time elapsed: 0:00:00.204162
```

2. Run reconcile for `sccs/batch-01`

```shell
pipenv run dsc -w "sccs" -c "abc123" -b "batch-01" -e "me@gmail.com" reconcile       
```

You should see the following output: 

```shell
Loading .env environment variables...
Courtesy Notice: Pipenv found itself running within a virtual environment, so it will automatically use that environment, instead of creating its own for any project. You can set PIPENV_IGNORE_VIRTUALENVS=1 to force pipenv to ignore that environment and create its own instead. You can set PIPENV_VERBOSITY=-1 to suppress this warning.
2025-01-31 09:00:26,294 INFO root.configure_logger(): INFO
2025-01-31 09:00:26,294 INFO dsc.cli.main(): Logger 'root' configured with level=INFO
2025-01-31 09:00:26,294 INFO dsc.cli.main(): No Sentry DSN found, exceptions will not be sent to Sentry
2025-01-31 09:00:26,294 INFO dsc.cli.main(): Running process
2025-01-31 09:00:26,307 INFO botocore.credentials.load(): Found credentials in environment variables.
2025-01-31 09:00:26,427 INFO botocore.configprovider.provide(): Found endpoint for s3 via: environment_global.
2025-01-31 09:00:26,473 INFO botocore.configprovider.provide(): Found endpoint for s3 via: environment_global.
2025-01-31 09:00:26,481 INFO botocore.httpchecksum.handle_checksum_body(): Skipping checksum validation. Response did not contain one of the following algorithms: ['crc32', 'sha1', 'sha256'].
2025-01-31 09:00:26,482 ERROR dsc.workflows.base.simple_csv.reconcile_bitstreams_and_metadata(): Failed to reconcile bitstreams and metadata. Bitstreams without metadata (n=0): []. Metadata without bitstreams (n=4): ["D3DD00227F.pdf", "D3MA00799E.pdf", "D3SC05353A.pdf", "D3MH01277H.pdf"].
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/jcuerdo/.local/share/virtualenvs/dspace-submission-composer-Bjkxt-Zn/lib/python3.12/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jcuerdo/.local/share/virtualenvs/dspace-submission-composer-Bjkxt-Zn/lib/python3.12/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/jcuerdo/.local/share/virtualenvs/dspace-submission-composer-Bjkxt-Zn/lib/python3.12/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jcuerdo/.local/share/virtualenvs/dspace-submission-composer-Bjkxt-Zn/lib/python3.12/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jcuerdo/.local/share/virtualenvs/dspace-submission-composer-Bjkxt-Zn/lib/python3.12/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jcuerdo/.local/share/virtualenvs/dspace-submission-composer-Bjkxt-Zn/lib/python3.12/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jcuerdo/Documents/repos/dspace-submission-composer/dsc/cli.py", line 108, in reconcile
    workflow.reconcile_bitstreams_and_metadata()
  File "/Users/jcuerdo/Documents/repos/dspace-submission-composer/dsc/workflows/base/simple_csv.py", line 60, in reconcile_bitstreams_and_metadata
    raise ReconcileError(reconcile_error_message)
dsc.exceptions.ReconcileError: Failed to reconcile bitstreams and metadata. Bitstreams without metadata (n=0): []. Metadata without bitstreams (n=4): ["D3DD00227F.pdf", "D3MA00799E.pdf", "D3SC05353A.pdf", "D3MH01277H.pdf"].
```

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1158

### Developer
- [x] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

