### PR TITLE
In 1172 improve logging for submit and finalize methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ DSC_SOURCE_EMAIL=### The email address from which SES emails are sent.
 ### Optional
 
 ```shell
-LOG_LEVEL=### Logging level. Defaults to 'INFO'.
-MINIO_S3_LOCAL_STORAGE=# full file system path to the directory where MinIO stores its object data on the local disk
-MINIO_S3_URL=# endpoint for MinIO server API; default is "http://localhost:9000/"
-MINIO_S3_CONTAINER_URL=# endpoint for the MinIO server when acccessed from inside a Docker container; default is "http://host.docker.internal:9000/"
-MINIO_ROOT_USER=# username for root user account for MinIO server
-MINIO_ROOT_PASSWORD=# password for root user account MinIO server
+WARNING_ONLY_LOGGERS=# Comma-separated list of logger names to set as WARNING only, e.g. 'botocore,smart_open,urllib3'.
+MINIO_S3_LOCAL_STORAGE=# Full file system path to the directory where MinIO stores its object data on the local disk.
+MINIO_S3_URL=# Endpoint for MinIO server API; default is "http://localhost:9000/".
+MINIO_S3_CONTAINER_URL=# Endpoint for the MinIO server when acccessed from inside a Docker container; default is "http://host.docker.internal:9000/".
+MINIO_ROOT_USER=# Username for root user account for MinIO server.
+MINIO_ROOT_PASSWORD=# Password for root user account MinIO server.
 ```
 
 

--- a/dsc/cli.py
+++ b/dsc/cli.py
@@ -118,7 +118,7 @@ def submit(
 def finalize(ctx: click.Context, email_recipients: str) -> None:
     """Process the result messages from the DSS output queue according the workflow."""
     workflow = ctx.obj["workflow"]
-    workflow.process_results()
+    workflow.process_ingest_results()
     workflow.send_report(
         report_class=FinalizeReport, email_recipients=email_recipients.split(",")
     )

--- a/dsc/cli.py
+++ b/dsc/cli.py
@@ -103,7 +103,7 @@ def submit(
 ) -> None:
     """Send a batch of item submissions to the DSpace Submission Service (DSS)."""
     workflow = ctx.obj["workflow"]
-    logger.debug(f"Beginning submission of batch ID: {workflow.batch_id}")
+    logger.info(f"Beginning submission of batch ID: {workflow.batch_id}")
     workflow.submit_items(collection_handle)
     # TODO(): workflow.send_report(email_recipients.split(",")) #noqa:FIX002, TD003
 

--- a/dsc/cli.py
+++ b/dsc/cli.py
@@ -103,7 +103,6 @@ def submit(
 ) -> None:
     """Send a batch of item submissions to the DSpace Submission Service (DSS)."""
     workflow = ctx.obj["workflow"]
-    logger.info(f"Beginning submission of batch ID: {workflow.batch_id}")
     workflow.submit_items(collection_handle)
     # TODO(): workflow.send_report(email_recipients.split(",")) #noqa:FIX002, TD003
 

--- a/dsc/utilities/aws/sqs.py
+++ b/dsc/utilities/aws/sqs.py
@@ -103,52 +103,16 @@ class SQSClient:
             }
         )
 
-    def delete(self, receipt_handle: str) -> EmptyResponseMetadataTypeDef:
-        """Delete message from SQS queue.
-
-        Args:
-            receipt_handle: The receipt handle of the message to be deleted.
-        """
-        logger.debug("Deleting '{receipt_handle}' from SQS queue: {self.queue_name}")
+    def delete(
+        self, receipt_handle: str, message_id: str
+    ) -> EmptyResponseMetadataTypeDef:
+        """Delete message from SQS queue."""
         response = self.client.delete_message(
             QueueUrl=self.queue_url,
             ReceiptHandle=receipt_handle,
         )
-        logger.debug(f"Message deleted from SQS queue: {response}")
-
+        logger.debug(f"Deleted message: {message_id}")
         return response
-
-    def process_result_message(self, sqs_message: MessageTypeDef) -> tuple[str, dict]:
-        """Validate, extract data, and delete an SQS result message.
-
-        Args:
-            sqs_message: An SQS result message to be processed.
-        """
-        self.validate_result_message(sqs_message)
-        item_identifier = sqs_message["MessageAttributes"]["PackageID"]["StringValue"]
-        message_body = json.loads(sqs_message["Body"])
-        logger.info(f"Item identifier: '{item_identifier}', Result: {message_body}")
-        self.delete(sqs_message["ReceiptHandle"])
-        return item_identifier, message_body
-
-    def receive(self) -> Iterator[MessageTypeDef]:
-        """Receive messages from SQS queue."""
-        logger.debug(f"Receiving messages from SQS queue: '{self.queue_name}'")
-        while True:
-            response = self.client.receive_message(
-                QueueUrl=self.queue_url,
-                MaxNumberOfMessages=10,
-                MessageAttributeNames=["All"],
-            )
-            if "Messages" in response:
-                for message in response["Messages"]:
-                    logger.debug(
-                        f"Message retrieved from SQS queue '{self.queue_name}': {message}"
-                    )
-                    yield message
-            else:
-                logger.debug(f"No more messages from SQS queue: '{self.queue_name}'")
-                break
 
     def send(
         self,
@@ -161,25 +125,59 @@ class SQSClient:
             message_attributes: The attributes of the message to send.
             message_body: The body of the message to send.
         """
-        logger.debug(f"Sending message to SQS queue: {self.queue_name}")
         response = self.client.send_message(
             QueueUrl=self.queue_url,
             MessageAttributes=message_attributes,
             MessageBody=str(message_body),
         )
-        logger.debug(f"Response from SQS queue: {response}")
+        logger.debug(f"Sent message: {response["MessageId"]}")
         return response
 
-    def validate_result_message(self, sqs_message: MessageTypeDef) -> None:
-        """Validate that an SQS result message is formatted as expected.
+    def receive(self) -> Iterator[MessageTypeDef]:
+        """Receive messages from SQS queue."""
+        message_count = 0
+        logger.debug(f"Receiving messages from the queue '{self.queue_name}'")
+
+        while True:
+            response = self.client.receive_message(
+                QueueUrl=self.queue_url,
+                MaxNumberOfMessages=10,
+                MessageAttributeNames=["All"],
+            )
+            if "Messages" in response:
+                for message in response["Messages"]:
+                    logger.debug(f"Retrieved message: {message["MessageId"]}")
+                    message_count += 1
+                    yield message
+            else:
+                if message_count == 0:
+                    logger.info(f"No messages found in the queue '{self.queue_name}'")
+                else:
+                    logger.info(f"No messages remain in the queue '{self.queue_name}'")
+                break
+
+        logger.info(
+            f"Retrieved {message_count} message(s) from the queue '{self.queue_name}'"
+        )
+
+    def parse_dss_result_message(self, sqs_message: MessageTypeDef) -> tuple[str, dict]:
+        message_id = sqs_message["MessageId"]
+        self.validate_dss_result_message(sqs_message)
+        item_identifier = sqs_message["MessageAttributes"]["PackageID"]["StringValue"]
+        message_body = json.loads(sqs_message["Body"])
+        logger.debug(f"Parsed message: {message_id}")
+        return item_identifier, message_body
+
+    def validate_dss_result_message(self, sqs_message: MessageTypeDef) -> None:
+        """Validate format of DSS result message.
 
         Args:
-            sqs_message:  An SQS message to be evaluated.
-
+            sqs_message: An SQS message to be evaluated.
         """
         if not sqs_message.get("ReceiptHandle"):
             raise InvalidSQSMessageError(
-                f"Failed to retrieve 'ReceiptHandle' from message: {sqs_message}"
+                "Failed to retrieve 'ReceiptHandle' from message: "
+                f"{sqs_message["MessageId"]}"
             )
         self.validate_message_attributes(sqs_message=sqs_message)
         self.validate_message_body(sqs_message=sqs_message)
@@ -197,7 +195,7 @@ class SQSClient:
             or not sqs_message["MessageAttributes"]["PackageID"].get("StringValue")
         ):
             raise InvalidSQSMessageError(
-                f"Failed to parse SQS message attributes: {sqs_message}"
+                f"Failed to parse message attributes: {sqs_message["MessageId"]}"
             )
 
     @staticmethod
@@ -209,5 +207,5 @@ class SQSClient:
         """
         if "Body" not in sqs_message or not json.loads(str(sqs_message["Body"])):
             raise InvalidSQSMessageError(
-                f"Failed to parse SQS message body: {sqs_message}"
+                f"Failed to parse message body: {sqs_message["MessageId"]}"
             )

--- a/dsc/utilities/aws/sqs.py
+++ b/dsc/utilities/aws/sqs.py
@@ -128,7 +128,7 @@ class SQSClient:
         response = self.client.send_message(
             QueueUrl=self.queue_url,
             MessageAttributes=message_attributes,
-            MessageBody=str(message_body),
+            MessageBody=message_body,
         )
         logger.debug(f"Sent message: {response["MessageId"]}")
         return response

--- a/dsc/workflows/base/__init__.py
+++ b/dsc/workflows/base/__init__.py
@@ -1,4 +1,3 @@
-# ruff: noqa: BLE001, TRY400
 from __future__ import annotations
 
 import json
@@ -158,8 +157,10 @@ class Workflow(ABC):
 
             try:
                 item_submission.upload_dspace_metadata(self.s3_bucket, self.batch_path)
-            except Exception as exception:
-                logger.error(f"Failed to upload DSpace metadata for item. {exception}")
+            except Exception as exception:  # noqa: BLE001
+                logger.error(  # noqa: TRY400
+                    f"Failed to upload DSpace metadata for item. {exception}"
+                )
                 self.workflow_events.errors.append(str(exception))
                 submission_summary["errors"] += 1
                 continue
@@ -172,15 +173,15 @@ class Workflow(ABC):
                     collection_handle,
                 )
             except ClientError as exception:
-                logger.error(
+                logger.error(  # noqa: TRY400
                     f"Failed to send submission message for item: {item_identifier}. "
                     f"{exception}"
                 )
                 self.workflow_events.errors.append(str(exception))
                 submission_summary["errors"] += 1
                 continue
-            except Exception as exception:
-                logger.error(
+            except Exception as exception:  # noqa: BLE001
+                logger.error(  # noqa: TRY400
                     f"Unexpected error occurred while sending submission message "
                     f"for item: {item_identifier}. {exception}"
                 )
@@ -331,7 +332,7 @@ class Workflow(ABC):
         """
 
     @final
-    def process_results(self) -> None:
+    def process_ingest_results(self) -> None:
         """Process DSS results from the workflow's output queue.
 
         Must NOT be overridden by workflow subclasses.
@@ -364,8 +365,8 @@ class Workflow(ABC):
                 item_identifier, result_message_body = (
                     sqs_client.parse_dss_result_message(sqs_message)
                 )
-            except Exception as exception:
-                logger.error(exception)
+            except Exception as exception:  # noqa: BLE001
+                logger.error(exception)  # noqa: TRY400
                 processing_summary["errors"] += 1
                 self.workflow_events.errors.append(str(exception))
                 continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import csv
 import json
+import uuid
 from io import StringIO
 
 import boto3
@@ -240,7 +241,7 @@ def mocked_ses(config_instance):
 @pytest.fixture
 def mocked_sqs_input(config_instance):
     with mock_aws():
-        sqs = boto3.resource("sqs", region_name=config_instance.aws_region_name)
+        sqs = boto3.client("sqs", region_name=config_instance.aws_region_name)
         sqs.create_queue(QueueName="mock-input-queue")
         yield sqs
 
@@ -248,7 +249,7 @@ def mocked_sqs_input(config_instance):
 @pytest.fixture
 def mocked_sqs_output():
     with mock_aws():
-        sqs = boto3.resource("sqs", region_name="us-east-1")
+        sqs = boto3.client("sqs", region_name="us-east-1")
         sqs.create_queue(QueueName="mock-output-queue")
         yield sqs
 
@@ -288,6 +289,7 @@ def result_message_valid(result_message_attributes, result_message_body):
         "ReceiptHandle": "lvpqxcxlmyaowrhbvxadosldaghhidsdralddmejhdrnrfeyfuphzs",
         "Body": result_message_body,
         "MessageAttributes": result_message_attributes,
+        "MessageId": uuid.uuid4(),
     }
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -142,11 +142,14 @@ def test_finalize_success(
     )
 
     assert result.exit_code == 0
-    assert "Processing result messages in 'mock-output-queue'" in caplog.text
-    assert "Receiving messages from SQS queue: 'mock-output-queue'" in caplog.text
-    assert "Message retrieved from SQS queue 'mock-output-queue':" in caplog.text
-    assert "No more messages from SQS queue: 'mock-output-queue'" in caplog.text
-    assert "Messages received and deleted from 'mock-output-queue'" in caplog.text
+    assert (
+        "Processing DSS result messages from the output queue 'mock-output-queue'"
+        in caplog.text
+    )
+    assert "Receiving messages from the queue 'mock-output-queue'" in caplog.text
+    assert "Retrieved message" in caplog.text
+    assert "Parsed message" in caplog.text
+    assert "No messages remain in the queue 'mock-output-queue'" in caplog.text
     assert "Logs sent to ['test@test.test', 'test2@test.test']" in caplog.text
     assert "Application exiting" in caplog.text
     assert "Total time elapsed" in caplog.text

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -129,7 +129,7 @@ def test_sqs_parse_dss_result_message_invalid_message_raises_exception(
     mocked_sqs_output,
     sqs_client,
 ):
-    sqs_client.send(message_attributes={}, message_body={})
+    sqs_client.send(message_attributes={}, message_body="")
     messages = sqs_client.receive()
     with pytest.raises(InvalidSQSMessageError):
         sqs_client.parse_dss_result_message(


### PR DESCRIPTION
### Purpose and background context

This PR aims to improve the logging of the DSC application for the `submit` and `finalize` CLI commands to ensure clear, detailed messages are logged that can help with debugging. This PR focuses on the two commands that are expected to be universal across DSC workflows. There is minimal logging for the `reconcile` command, but it is also expected to be opinionated for a given workflow. 

The changes to improve logging are structured somewhat similarly for the two CLI commands:

* Logging a "start" and "end" message for the main entry method (i.e., `Workflow.submit_items` and `Workflow.process_sqs_queue`)
* Creating a "_summary" dictionary to keep track of outcomes during runs (i.e., [`submission_summary`](https://github.com/MITLibraries/dspace-submission-composer/pull/144/files#diff-9409cf7165577c3250e707080466409d47908aae682829ddb8a1abadecda795aR148-R152) and [`processing_summary`](https://github.com/MITLibraries/dspace-submission-composer/pull/144/files#diff-9409cf7165577c3250e707080466409d47908aae682829ddb8a1abadecda795aR350-R354))
* Logging "_summary" dictionary in the "end" message as a serialized JSON formatted string
* Using `try-except` blocks to capture errors in key function calls and using `logger.error` over `logger.exception` to simplify logged error messages

This PR also includes [updates to `Config` to support a `WARNING_ONLY_LOGGERS` environment variable](https://github.com/MITLibraries/dspace-submission-composer/pull/144/commits/86a433d16b7a3a6f3bf68ace7c53173d8510cbf4).

### How can a reviewer manually see the effects of these changes?
As of this writing, testing DSC is a bit complex for a couple of reasons: awaiting AWS infrastructure for DSC (currently using `wiley-deposits` S3 bucket and output SQS queue) and issues with the test instance of DSpace@MIT (mit-test.atmire.com) resulting in item submissions failing to get ingested.  

For purposes of knowledge-sharing, instructions for the commands I ran to generate some of the logs below are shared in **B**. However, reviewing the logs shared in **A** should be sufficient for PR review.

Note: There is a [ticket in the epic to create integration tests](https://mitlibraries.atlassian.net/browse/IN-1166).

### A. Review logs

For these runs, the env var `WARNING_ONLY_LOGGERS` was set to `botocore,smart_open,urllib3` and reporting was turned off for the `finalize` command.

* Submit
   * [dsc_submit_nonverbose_submitted_2024-12-19.txt](https://github.com/user-attachments/files/18869959/dsc_submit_nonverbose_submitted_2024-12-19.txt): Demonstrates successful sending of item submission messages to the DSS queue, with _non-verbose_ logging.
   * [dsc_submit_verbose_submitted_2024-12-19.txt](https://github.com/user-attachments/files/18870012/dsc_submit_verbose_submitted_2024-12-19.txt): Demonstrates successful sending of item submission messages to the DSS queue, with _verbose_ logging. Compared to the _non-verbose_ version, there are additional logs for each item on the validation and upload of created DSpace metadata.

* Finalize
   * [dsc_finalize_nonverbose_no_messages_2025-02-19.txt](https://github.com/user-attachments/files/18870034/dsc_finalize_nonverbose_no_messages_2025-02-19.txt): Demonstrates `finalize` run when no messages are in the output queue, with _non-verbose_ logging.
   * [dsc_finalize_verbose_no_messages_2025-02-19.txt](https://github.com/user-attachments/files/18870065/dsc_finalize_verbose_no_messages_2025-02-19.txt): Demonstrates `finalize` run when no messages are in the output queue, with _verbose_ logging. Compared to the _non-verbose_ version, there is an additional log from `dsc.utilities.aws.sqs.receive()`, indicating messages are being received.
   * [dsc_finalize_nonverbose_unparsed_messages_2025-02-19.txt](https://github.com/user-attachments/files/18870029/dsc_finalize_nonverbose_unparsed_messages_2025-02-19.txt): Demonstrates `finalize` run when 2/5 messages fail parsing (i.e., invalid DSS result messages due to removal of `ReceiptHandle`), with _non-verbose_ logging. 
      * **Note:** 2 messages indicating failure to retrieve `ReceiptHandle`, 3 messages indicating failure to ingest. Both of these outcomes are considered errors, but the 3 parsed items are included in the returned `items` list for extra processing + reporting.
   * [dsc_finalize_verbose_unparsed_messages_2025-02-19.txt](https://github.com/user-attachments/files/18870163/dsc_finalize_verbose_unparsed_messages_2025-02-19.txt): Demonstrates `finalize` run when 2/5 messages fail parsing (i.e., invalid DSS result messages due to removal of `ReceiptHandle`), with _verbose_ logging. Compared to the _non-verbose_ version, there are additional logs for each item for various `SQSClient` commands.
   * [dsc_finalize_nonverbose_parsed_messages_2025-02-19.txt](https://github.com/user-attachments/files/18870268/dsc_finalize_nonverbose_parsed_messages_2025-02-19.txt): Demonstrates `finalize` run when 5/5 messages pass parsing (i.e., valid DSS result messages), with _non-verbose_ logging.
      * **Note:** 5 messages indicating item was not ingested. This outcome is considered an error, and all 5 parsed items are included in the returned `items` list for extra processing + reporting. 
   * [dsc_finalize_verbose_parsed_messages_2025-02-19.txt](https://github.com/user-attachments/files/18870276/dsc_finalize_verbose_parsed_messages_2025-02-19.txt): Demonstrates `finalize` run when 5/5 messages pass parsing (i.e., valid DSS result messages), with _verbose_ logging. Compared to the _non-verbose_ version, there are additional logs for each item for various `SQSClient` commands.

### B. Sample run

1. Open two terminals. Set `AWSAdministratorAccess` credentials for Dev in both terminals. Set one terminal to the DSS repo (`main` branch). 
2. Follow the instructions in the Google doc [DSC Testing with wiley-deposits infrastructure | Testing for OpenCourseWare (OCW) workflow](https://docs.google.com/document/d/1h9ftmfkN7Jh4sun--YDG12oUjMRPuHm6z_mjq3IwJ8M/edit?tab=t.0), _**skip steps 2-3 (already performed)**_. For step 4, set the second terminal to the DSC repo (`IN-1172-improve-logging-for-submit-and-finalize-methods` branch).
3. Observe logs!

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
https://mitlibraries.atlassian.net/browse/IN-1172

### Developer
- [x] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

