### PR TITLE
Update SCCS metadata mapping JSON file and support reruns

### DIFF
--- a/dsc/cli.py
+++ b/dsc/cli.py
@@ -141,3 +141,34 @@ def finalize(ctx: click.Context, email_recipients: str) -> None:
     workflow.send_report(
         report_class=FinalizeReport, email_recipients=email_recipients.split(",")
     )
+
+
+@main.command()
+@click.pass_context
+@click.option(
+    "-i",
+    "--items",
+    help=(
+        "Item identifiers specifying which DSpace metadata JSON files "
+        "should be removed, formatted as a comma-delimited string"
+    ),
+    default=None,
+)
+@click.option(
+    "--remove-all",
+    help="Pass to delete all DSpace metadata JSON files in batch folder",
+    is_flag=True,
+)
+@click.option("--execute/--no-execute", help="Pass to perform deletions", default=False)
+def remove_dspace_metadata(
+    ctx: click.Context,
+    items: str | None = None,
+    *,
+    remove_all: bool = False,
+    execute: bool = False,
+) -> None:
+    """Bulk delete DSpace metadata JSON files from batch folder in S3."""
+    workflow = ctx.obj["workflow"]
+    workflow.remove_dspace_metadata(
+        item_identifiers=items, remove_all=remove_all, execute=execute
+    )

--- a/dsc/cli.py
+++ b/dsc/cli.py
@@ -100,6 +100,11 @@ def reconcile(ctx: click.Context, email_recipients: str | None = None) -> None:
     required=True,
 )
 @click.option(
+    "--skip-items",
+    help="Item identifiers to exclude from DSS submissions as a comma-delimited string",
+    default=None,
+)
+@click.option(
     "-e",
     "--email-recipients",
     help="The recipients of the submission results email as a comma-delimited string",
@@ -108,11 +113,12 @@ def reconcile(ctx: click.Context, email_recipients: str | None = None) -> None:
 def submit(
     ctx: click.Context,
     collection_handle: str,
+    skip_items: list | None = None,
     email_recipients: str | None = None,
 ) -> None:
     """Send a batch of item submissions to the DSpace Submission Service (DSS)."""
     workflow = ctx.obj["workflow"]
-    workflow.submit_items(collection_handle)
+    workflow.submit_items(collection_handle, skip_items)
 
     if email_recipients:
         workflow.send_report(

--- a/dsc/reports/finalize.py
+++ b/dsc/reports/finalize.py
@@ -77,6 +77,7 @@ class FinalizeReport(Report):
             batch_id=self.batch_id,
             report_date=self.report_date,
             processed_items=self.events.processed_items,
+            ingested_items=self.get_ingested_items(),
             errors=self.events.errors,
         )
 
@@ -86,5 +87,6 @@ class FinalizeReport(Report):
             batch_id=self.batch_id,
             report_date=self.report_date,
             processed_items=self.events.processed_items,
+            ingested_items=self.get_ingested_items(),
             errors=self.events.errors,
         )

--- a/dsc/reports/templates/html/finalize.html
+++ b/dsc/reports/templates/html/finalize.html
@@ -7,7 +7,7 @@
 <p>Run date: {{report_date}}</p>
 
 <p>Results:</p>
-<p>Ingested: {{ processed_items|length }}</p>
+<p>Processed: {{ processed_items|length }}</p>
+<p>Ingested: {{ ingested_items | length }}</p>
 <p>Errors: {{ errors|length }}</p>
-
 {% endblock %}

--- a/dsc/reports/templates/plain_text/finalize.txt
+++ b/dsc/reports/templates/plain_text/finalize.txt
@@ -6,6 +6,7 @@ Batch: {{batch_id}}
 Run date: {{report_date}}
 
 Results:
-Ingested: {{ processed_items|length }}
+Processed: {{ processed_items|length }}
+Ingested: {{ ingested_items|length }}
 Errors: {{ errors|length }}
 {% endblock %}

--- a/dsc/utilities/aws/s3.py
+++ b/dsc/utilities/aws/s3.py
@@ -57,6 +57,12 @@ class S3Client:
         logger.debug(f"'{key}' uploaded to S3")
         return response
 
+    def delete_files(self, bucket: str, files: list[str]) -> None:
+        objects_to_delete = [{"Key": object_key} for object_key in files]
+        self.client.delete_objects(
+            Bucket=bucket, Delete={"Objects": objects_to_delete, "Quiet": True}  # type: ignore[typeddict-item]
+        )
+
     def files_iter(
         self,
         bucket: str,

--- a/dsc/workflows/base/simple_csv.py
+++ b/dsc/workflows/base/simple_csv.py
@@ -151,6 +151,7 @@ class SimpleCSV(Workflow):
         ) as csvfile:
             metadata_df = pd.read_csv(csvfile, dtype="str")
             metadata_df = metadata_df.dropna(how="all")
+            metadata_df = metadata_df.where(pd.notna(metadata_df), None)
 
             for _, row in metadata_df.iterrows():
                 yield row.to_dict()

--- a/dsc/workflows/base/simple_csv.py
+++ b/dsc/workflows/base/simple_csv.py
@@ -56,7 +56,7 @@ class SimpleCSV(Workflow):
             s3_client.files_iter(
                 bucket=self.s3_bucket,
                 prefix=self.batch_path,
-                exclude_prefixes=["archived", metadata_file],
+                exclude_prefixes=["archived", metadata_file, "metadata.json"],
             )
         )
 
@@ -180,7 +180,7 @@ class SimpleCSV(Workflow):
                 bucket=self.s3_bucket,
                 prefix=self.batch_path,
                 item_identifier=item_identifier,
-                exclude_prefixes=["archived"],
+                exclude_prefixes=["archived", "metadata.json"],
             )
         )
 

--- a/dsc/workflows/metadata_mapping/sccs.json
+++ b/dsc/workflows/metadata_mapping/sccs.json
@@ -29,6 +29,9 @@
         "language": "en_US",
         "delimiter": "|"
     },
+    "dc.contributor.department": {
+        "source_field_name": "dc.contributor.department"
+    },
     "dc.relation.isversionof": {
         "source_field_name": "dc.relation.isversionof"
     },
@@ -47,6 +50,9 @@
     },
     "dc.rights.uri": {
         "source_field_name": "dc.rights.uri"
+    },
+    "dc.description": {
+        "source_field_name": "dc.description"
     },
     "dc.description.sponsorship": {
         "source_field_name": "dc.description.sponsorship",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -174,3 +174,80 @@ def test_finalize_success(
     assert "Logs sent to ['test@test.test', 'test2@test.test']" in caplog.text
     assert "Application exiting" in caplog.text
     assert "Total time elapsed" in caplog.text
+
+
+def test_remove_dspace_metadata_if_remove_all_success(
+    caplog, runner, base_workflow_instance, mocked_s3, s3_client
+):
+    s3_client.put_file(
+        file_content="",
+        bucket="dsc",
+        key="test/batch-aaa/123.pdf_metadata.json",
+    )
+    s3_client.put_file(
+        file_content="",
+        bucket="dsc",
+        key="test/batch-aaa/124.pdf_metadata.json",
+    )
+
+    result = runner.invoke(
+        main,
+        [
+            "--verbose",
+            "--workflow-name",
+            "test",
+            "--batch-id",
+            "batch-aaa",
+            "remove-dspace-metadata",
+            "--remove-all",
+            "--execute",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Found 2 DSpace metadata JSON file(s) to delete" in caplog.text
+    assert (
+        str(
+            [
+                "test/batch-aaa/123.pdf_metadata.json",
+                "test/batch-aaa/124.pdf_metadata.json",
+            ]
+        )
+        in caplog.text
+    )
+    assert "Deleting 2 DSpace metadata JSON file(s)" in caplog.text
+
+
+def test_remove_dspace_metadata_if_item_identifiers_success(
+    caplog, runner, base_workflow_instance, mocked_s3, s3_client
+):
+    s3_client.put_file(
+        file_content="",
+        bucket="dsc",
+        key="test/batch-aaa/123.pdf_metadata.json",
+    )
+    s3_client.put_file(
+        file_content="",
+        bucket="dsc",
+        key="test/batch-aaa/124.pdf_metadata.json",
+    )
+
+    result = runner.invoke(
+        main,
+        [
+            "--verbose",
+            "--workflow-name",
+            "test",
+            "--batch-id",
+            "batch-aaa",
+            "remove-dspace-metadata",
+            "--items",
+            "123.pdf",
+            "--execute",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Found 1 DSpace metadata JSON file(s) to delete" in caplog.text
+    assert str(["test/batch-aaa/123.pdf_metadata.json"]) in caplog.text
+    assert "Deleting 1 DSpace metadata JSON file(s)" in caplog.text


### PR DESCRIPTION
### Purpose and background context

The initial goal of this PR was update the SCCS metadata mapping JSON file to fulfill [a batch deposit request for SCCS
](https://mitlibraries.atlassian.net/browse/INFRA-509), which is encapsulated in the first commit https://github.com/MITLibraries/dspace-submission-composer/pull/169/commits/64da73e1d32bf4996f26b0f8a964bfd1e06532a0. The following screenshots and attachments show the results of the full DSC workflow run for this deposit. 

* DSC Reconcile Results - sccs, batch='sccs-batch-2025-02-09-mit-annual-reports' (sent at 9:41AM)
   * [reconciled_items.csv](https://github.com/user-attachments/files/19075664/reconciled_items.csv)
   <img width="671" alt="image" src="https://github.com/user-attachments/assets/b0ad6a5f-f28d-4b98-a698-3e7a892036dc" />
* DSC Submission Results - sccs, batch='sccs-batch-2025-02-09-mit-annual-reports' (sent at 9:42AM)
   * [submitted_items.csv](https://github.com/user-attachments/files/19075675/submitted_items.csv)
   <img width="950" alt="image" src="https://github.com/user-attachments/assets/9f1a75ea-0dc4-4062-8ce0-a2a36b5da9e7" />
* DSpace Submission Results - sccs, batch='sccs-batch-2025-02-09-mit-annual-reports'
   * [ingested_items.csv](https://github.com/user-attachments/files/19075680/ingested_items.csv)
   * [errors.csv](https://github.com/user-attachments/files/19075702/errors.csv)
   <img width="941" alt="image" src="https://github.com/user-attachments/assets/b003c07f-f52f-4eb0-b691-df3527c321b7" />

As the third email shows, of the 106 items in the batch, 78 were successfully ingested by DSpace@MIT and 28 failed ingestion. These results served as the motivation for the other commits in this PR, which aim to address: **how can we easily re-run DSC submissions on a subset of data (e.g., items that failed ingest)?** 

The additional commits are:
* [Add option `--skip-items` to `submit` CLI command to skip item submissions using a list of item identifiers](https://github.com/MITLibraries/dspace-submission-composer/pull/169/commits/f49bdaca18af0d22bbc86a789240d41b8e481da5)
   * **How is this useful:** Retrieve list of item identifiers from `ingested_items.csv` to avoid re-submitting items that were already successfully ingested. If you rerun the `submit` command, passing a comma-delimited string of these item identifiers to `--skip-items` will effectively result in DSC only submitting items that **do not** show up in the list.
* [Fix counts in `FinalizeReport`](https://github.com/MITLibraries/dspace-submission-composer/pull/169/commits/70f5ce0a484b8b830c501a64e67f26258e4a9d7e)
   * **How is this useful:** Corrects the error in the third screenshot shared above. The email should've clearly indicated that 106 messages were _processed_, 78 items were _ingested_, and 28 items _encountered errors_.
* [Create CLI command to bulk-delete metadata JSON files](https://github.com/MITLibraries/dspace-submission-composer/pull/169/commits/841cf566609efc7121723b767560d51d347e0e20).
   * **How is this useful:** One of the steps to "reset" a deposit is to remove the DSpace metadata JSON files generated by DSC from the batch folder in S3. This is in order to avoid the inclusion of the DSpace metadata JSON files as bitstreams (in the case of reruns).
      * **Why would the DSpace metdata JSON files get included as a bitstream?**: For every item in a batch, `Workflow.get_bitstream_s3_uris` should capture _any_ files in the batch folder that include the "item identifier" (for the item) in the object prefix. Unless we know [_all the files for every deposit for a given workflow will strictly follow a format and/or data type_](https://github.com/MITLibraries/dspace-submission-composer/blob/INFRA-509-sccs-deposit-request/dsc/workflows/opencourseware.py#L232-L242), we generally want these functions to be "greedy" when finding files. Thusly, if the DSpace metadata JSON files -- which always includes the item identifier in the object prefix -- from a previous run are still in the bucket, these will be included as bitstreams for the item. Thinking about this question led to the addition of one more commit (see next bullet)!
* [Update `SimpleCSV` to exclude DSpace metadata JSON files when retrieving bitstreams](https://github.com/MITLibraries/dspace-submission-composer/pull/169/commits/f0f9860e00d483753f424458fc99da8937c844d9)
   * **How is this useful:** Additional safeguard to ensure these metadata JSON files are not included as bitstreams in the event of reruns. This means that using the CLI command to bulk-delete metadata JSON files is no longer required (but is available if needed) as rerunning will simply override the metadata JSON files in the batch folder in S3.
      * **Note:** Running `submit` _without_ `--skip-items` will result in all metadata JSON files being overwritten.

### How can a reviewer manually see the effects of these changes?

This assumes you have two terminals open with AWS Dev credentials loaded in; set current working directories to DSC and DSS repos, respectively!

**A. Updated SCCS metadata mapping JSON**
To demonstrate this, I ran the full DSC workflow for the batch deposit requested via [INFRA-509](https://mitlibraries.atlassian.net/browse/INFRA-509?focusedCommentId=147637&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-147637). 

* Items have been deposited to the following collection: https://mit-test.atmire.com/handle/1721.1/154307/recent-submissions.
* The following emails were relevant to this run:
   * DSC Reconcile Results - sccs, batch='sccs-batch-2025-02-09-mit-annual-reports' (sent at 3:07PM)
      ```
      Reconcile results summary for sccs deposit
      Batch: sccs-batch-2025-02-09-mit-annual-reports
      Run date: 2025-03-05 20:06:23

      Results:
      Reconciled: 106
      ```
   * DSC Submission Results - sccs, batch='sccs-batch-2025-02-09-mit-annual-reports' (sent at 3:10PM)
     ```
     Submission results for sccs deposit
     Batch: sccs-batch-2025-02-09-mit-annual-reports
     Run date: 2025-03-05 20:09:34

     Results:
     Messages successfully sent to DSS: 106
     Errors: 0
     ```
   * DSpace Submission Results - sccs, batch='sccs-batch-2025-02-09-mit-annual-reports' (sent at 3:18PM)
     ```
     Ingest results for sccs deposit
     Batch: sccs-batch-2025-02-09-mit-annual-reports
     Run date: 2025-03-05 20:17:48

     Results:
     Processed: 106
     Ingested: 105
     Errors: 1
     ```
   **Note:** One item failed ingest but resolving this is **outside the scope of this PR**.


**B. Skip items when submitting**
To demonstrate this, I ran the full DSC workflow twice using sample files for OpenCourseWare deposits:
* 1st run: All 5 items successfully ingested by DSpace
   * See `submit` report: DSC Submission Results - opencourseware, batch='ocw-batch-2025-02-10' (sent at 1:14PM) 
      ```
      Submission results for opencourseware deposit
      Batch: ocw-batch-2025-02-10
      Run date: 2025-03-05 18:13:26

      Results:
      Messages successfully sent to DSS: 5
      Errors: 0
      ```
   * See `finalize` report: DSpace Submission Results - opencourseware, batch='ocw-batch-2025-02-10'
      ```
      Ingest results for opencourseware deposit
      Batch: ocw-batch-2025-02-10
      Run date: 2025-03-05 18:20:08

      Results:
      Processed: 5
      Ingested: 5
      Errors: 0
      ```

* 2nd run: A single item is successfully re-ingested by DSpace (results in duplicate item in DSpace) (via `--skip-items "<item-identifiers-for-4-ingested-items>"`)
   * Download [ingested_items.csv](https://github.com/user-attachments/files/19094743/ingested_items.csv)
 from `finalize` report (I just copy this file into the root of the `dspace-submission-composer` repo). Retrieve item identifiers from the CSV. Run `pipenv run python` and execute the following commands:
     ```python
     import pandas as pd
     
     df = pd.read_csv("ingested_items.csv")
     ",".join(df["item_identifier"].to_list()[:4])
     ```
      Copy the generated string.
   * Rerun `submit` CLI command: 
      ```shell
      pipenv run dsc --workflow-name="opencourseware" --batch-id=ocw-batch-2025-02-10 submit -c /1721.1/154279 --skip-items '21g.321-spring-2013,21g.346-spring-2014,wgs.301j-fall-2014,14.02-fall-2004'
      ```
      You should see the following logs:
```text
2025-03-05 13:31:00,446 INFO dsc.cli.main(): Logger 'root' configured with level=INFO
2025-03-05 13:31:00,446 INFO dsc.cli.main(): No Sentry DSN found, exceptions will not be sent to Sentry
2025-03-05 13:31:00,446 INFO dsc.cli.main(): Running process
2025-03-05 13:31:00,447 INFO dsc.workflows.base.submit_items(): Submitting messages to the DSS input queue 'dss-input-dev' for batch 'ocw-batch-2025-02-10'
2025-03-05 13:31:01,940 INFO dsc.workflows.base.item_submissions_iter(): Skipping submission for item: 14.02-fall-2004
2025-03-05 13:31:02,955 INFO dsc.workflows.base.item_submissions_iter(): Preparing submission for item: 14.02-spring-2014
2025-03-05 13:31:03,474 INFO dsc.item_submission.upload_dspace_metadata(): Metadata uploaded to S3: s3://wiley-files-dev-222053980223/opencourseware/ocw-batch-2025-02-10/14.02-spring-2014_metadata.json
2025-03-05 13:31:03,759 INFO dsc.workflows.base.submit_items(): Sent item submission message: 5b0e5c0b-b7a3-4642-9f54-b8dc603a8817
2025-03-05 13:31:04,763 INFO dsc.workflows.base.item_submissions_iter(): Skipping submission for item: 21g.321-spring-2013
2025-03-05 13:31:05,707 INFO dsc.workflows.base.item_submissions_iter(): Skipping submission for item: 21g.346-spring-2014
2025-03-05 13:31:06,782 INFO dsc.workflows.base.item_submissions_iter(): Skipping submission for item: wgs.301j-fall-2014
2025-03-05 13:31:06,785 INFO dsc.workflows.base.submit_items(): Submitted messages to the DSS input queue 'dss-input-dev' for batch 'ocw-batch-2025-02-10': {"total": 1, "submitted": 1, "errors": 0}
2025-03-05 13:31:07,103 INFO dsc.cli.post_main_group_subcommand(): Application exiting
2025-03-05 13:31:07,103 INFO dsc.cli.post_main_group_subcommand(): Total time elapsed: 0:00:06.658427
```
   * See `submit` report: DSC Submission Results - opencourseware, batch='ocw-batch-2025-02-10' (sent at 1:32PM)
      ```
      Submission results for opencourseware deposit
      Batch: ocw-batch-2025-02-10
      Run date: 2025-03-05 18:31:06

      Results:
      Messages successfully sent to DSS: 1
      Errors: 0
      ```
   * Run DSS in Dev.
   * See `finalize` report: DSpace Submission Results - opencourseware, batch='ocw-batch-2025-02-10' (sent at 1:36PM)
      ```
      Ingest results for opencourseware deposit
      Batch: ocw-batch-2025-02-10
      Run date: 2025-03-05 18:36:21

      Results:
      Processed: 1 # <---- fixed counts!
      Ingested: 1 # <---- fixed counts!
      Errors: 0
      ```
   * If you take a look at [the collection in Dev DSpace@MIT](https://mit-test.atmire.com/handle/1721.1/154279/recent-submissions), it should show 6 items (or 6 + n, where n = the number of times you execute the steps for the 2nd run 😉 ).

**C. Remove DSpace metadata JSON files**

1. Run the command:
   ```shell
   pipenv run dsc --workflow-name="opencourseware" --batch-id=ocw-batch-2025-03-05 remove-dspace-metadata --items "123.pdf,124.pdf"
   ```
   You should see the following output:
```text
2025-03-05 13:49:49,115 INFO dsc.cli.main(): Logger 'root' configured with level=INFO
2025-03-05 13:49:49,115 INFO dsc.cli.main(): No Sentry DSN found, exceptions will not be sent to Sentry
2025-03-05 13:49:49,115 INFO dsc.cli.main(): Running process
2025-03-05 13:49:49,189 INFO dsc.workflows.base.remove_dspace_metadata(): Searching for DSpace metadata JSON file(s) to delete
2025-03-05 13:49:49,333 INFO dsc.workflows.base.remove_dspace_metadata(): Found 2 DSpace metadata JSON file(s) to delete: ['opencourseware/ocw-batch-2025-03-05/123.pdf_metadata.json', 'opencourseware/ocw-batch-2025-03-05/124.pdf_metadata.json']
2025-03-05 13:49:49,334 INFO dsc.cli.post_main_group_subcommand(): Application exiting
2025-03-05 13:49:49,334 INFO dsc.cli.post_main_group_subcommand(): Total time elapsed: 0:00:00.219661
```
2. Run the command with `--execute`:
   ```
   pipenv run dsc --workflow-name="opencourseware" --batch-id=ocw-batch-2025-03-05 remove-dspace-metadata --items "123.pdf" --execute
   ```
   You should see the following output:
```text
2025-03-05 13:52:00,464 INFO dsc.cli.main(): Logger 'root' configured with level=INFO
2025-03-05 13:52:00,464 INFO dsc.cli.main(): No Sentry DSN found, exceptions will not be sent to Sentry
2025-03-05 13:52:00,464 INFO dsc.cli.main(): Running process
2025-03-05 13:52:00,566 INFO dsc.workflows.base.remove_dspace_metadata(): Searching for DSpace metadata JSON file(s) to delete
2025-03-05 13:52:00,763 INFO dsc.workflows.base.remove_dspace_metadata(): Found 1 DSpace metadata JSON file(s) to delete: ['opencourseware/ocw-batch-2025-03-05/123.pdf_metadata.json']
2025-03-05 13:52:00,763 WARNING dsc.workflows.base.remove_dspace_metadata(): Deleting 1 DSpace metadata JSON file(s)
2025-03-05 13:52:00,817 INFO dsc.cli.post_main_group_subcommand(): Application exiting
2025-03-05 13:52:00,817 INFO dsc.cli.post_main_group_subcommand(): Total time elapsed: 0:00:00.353228
```

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES | NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1199
- https://mitlibraries.atlassian.net/browse/INFRA-509

### Developer
- [x] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes



[INFRA-509]: https://mitlibraries.atlassian.net/browse/INFRA-509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ