### PR TITLE
Define 'output_queue' property for DSC workflows

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -72,12 +72,12 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb",
-                "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb"
+                "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d",
+                "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.5"
+            "version": "==3.1.6"
         },
         "jmespath": {
             "hashes": [

--- a/dsc/workflows/base/__init__.py
+++ b/dsc/workflows/base/__init__.py
@@ -81,9 +81,9 @@ class Workflow(ABC):
         return CONFIG.s3_bucket
 
     @property
-    @abstractmethod
     def output_queue(self) -> str:
         """The SQS output queue for the DSS result messages."""
+        return f"dss-output-{self.workflow_name}-{CONFIG.workspace}"
 
     @property
     def batch_path(self) -> str:

--- a/dsc/workflows/opencourseware.py
+++ b/dsc/workflows/opencourseware.py
@@ -27,10 +27,6 @@ class OpenCourseWare(Workflow):
     def metadata_mapping_path(self) -> str:
         return "dsc/workflows/metadata_mapping/opencourseware.json"
 
-    @property
-    def output_queue(self) -> str:
-        return "awaiting AWS infrastructure"
-
     def reconcile_bitstreams_and_metadata(self) -> bool:
         """Reconcile bitstreams against item metadata.
 

--- a/dsc/workflows/sccs.py
+++ b/dsc/workflows/sccs.py
@@ -17,10 +17,6 @@ class SCCS(SimpleCSV):
     def metadata_mapping_path(self) -> str:
         return "dsc/workflows/metadata_mapping/sccs.json"
 
-    @property
-    def output_queue(self) -> str:
-        return "awaiting AWS infrastructure"
-
     @staticmethod
     def get_item_identifier(item_metadata: dict[str, Any]) -> str:
         """Get 'item_identifier' from item metadata entry.


### PR DESCRIPTION
### Purpose and background context
With a future goal of having DSS support multiple input and output queues, it's important for DSC to apply a clear, consistent naming convention for the 'output_queue' property for all workflow classes.

### How can a reviewer manually see the effects of these changes?
DataEng will see the effects of the changes as a team during testing of the DSC state machine in Dev.

### Includes new or updated dependencies?
YES - update to `jinja2` to address linting error.

### Changes expectations for external applications?
YES - By default, all `Workflow` subclasses will expect an SQS output queue that follows the naming convention `dss-output-<workflow-name>-<workspace>`, unless the `output_queue` property is explicitly defined for the subclass.

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1235

### Developer
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [ ] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

