### PR TITLE
In 1323 improve methods for processing result messages

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ boto3 = "*"
 boto3-stubs = {extras = ["essential","ses"], version = "*"}
 click = "*"
 jinja2 = "*"
+jsonschema = "*"
 pandas = "*"
 sentry-sdk = "*"
 smart_open = {extras = ["s3"], version = "*"}
@@ -23,6 +24,7 @@ pip-audit = "*"
 pre-commit = "*"
 pytest = "*"
 ruff = "*"
+types-jsonschema = "*"
 
 [requires]
 python_version = "3.12"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a9e382c8d098244b7035f49a51a2eeeda75348a3fbabb4285102aa7743053140"
+            "sha256": "801d711537ecaf6ff9cf4f87456b7957ae8b01cb7e27cbf05cb1a9a485d53cae"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "attrs": {
+            "hashes": [
+                "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3",
+                "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==25.3.0"
+        },
         "boto3": {
             "hashes": [
                 "sha256:34c27d7317cadb62c0e9856e5d5aa0271ef47202d340584831048bc7ac904136",
@@ -86,6 +94,23 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==1.0.1"
+        },
+        "jsonschema": {
+            "hashes": [
+                "sha256:0b4e8069eb12aedfa881333004bccaec24ecef5a8a6a4b6df142b2cc9599d196",
+                "sha256:a462455f19f5faf404a7902952b6f0e3ce868f3ee09a359b05eca6673bd8412d"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==4.24.0"
+        },
+        "jsonschema-specifications": {
+            "hashes": [
+                "sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af",
+                "sha256:630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2025.4.1"
         },
         "markupsafe": {
             "hashes": [
@@ -321,7 +346,7 @@
                 "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
                 "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.9.0.post0"
         },
         "pytz": {
@@ -330,6 +355,137 @@
                 "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"
             ],
             "version": "==2025.2"
+        },
+        "referencing": {
+            "hashes": [
+                "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa",
+                "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==0.36.2"
+        },
+        "rpds-py": {
+            "hashes": [
+                "sha256:0317177b1e8691ab5879f4f33f4b6dc55ad3b344399e23df2e499de7b10a548d",
+                "sha256:036ded36bedb727beeabc16dc1dad7cb154b3fa444e936a03b67a86dc6a5066e",
+                "sha256:048893e902132fd6548a2e661fb38bf4896a89eea95ac5816cf443524a85556f",
+                "sha256:0701942049095741a8aeb298a31b203e735d1c61f4423511d2b1a41dcd8a16da",
+                "sha256:083a9513a33e0b92cf6e7a6366036c6bb43ea595332c1ab5c8ae329e4bcc0a9c",
+                "sha256:09eab132f41bf792c7a0ea1578e55df3f3e7f61888e340779b06050a9a3f16e9",
+                "sha256:0e6a327af8ebf6baba1c10fadd04964c1965d375d318f4435d5f3f9651550f4a",
+                "sha256:0eb90e94f43e5085623932b68840b6f379f26db7b5c2e6bcef3179bd83c9330f",
+                "sha256:114a07e85f32b125404f28f2ed0ba431685151c037a26032b213c882f26eb908",
+                "sha256:115874ae5e2fdcfc16b2aedc95b5eef4aebe91b28e7e21951eda8a5dc0d3461b",
+                "sha256:140f61d9bed7839446bdd44852e30195c8e520f81329b4201ceead4d64eb3a9f",
+                "sha256:1521031351865e0181bc585147624d66b3b00a84109b57fcb7a779c3ec3772cd",
+                "sha256:1c0c434a53714358532d13539272db75a5ed9df75a4a090a753ac7173ec14e11",
+                "sha256:1d1fadd539298e70cac2f2cb36f5b8a65f742b9b9f1014dd4ea1f7785e2470bf",
+                "sha256:1de336a4b164c9188cb23f3703adb74a7623ab32d20090d0e9bf499a2203ad65",
+                "sha256:1ee3e26eb83d39b886d2cb6e06ea701bba82ef30a0de044d34626ede51ec98b0",
+                "sha256:245550f5a1ac98504147cba96ffec8fabc22b610742e9150138e5d60774686d7",
+                "sha256:2a40046a529cc15cef88ac5ab589f83f739e2d332cb4d7399072242400ed68c9",
+                "sha256:2c2cd1a4b0c2b8c5e31ffff50d09f39906fe351389ba143c195566056c13a7ea",
+                "sha256:2cb9e5b5e26fc02c8a4345048cd9998c2aca7c2712bd1b36da0c72ee969a3523",
+                "sha256:33358883a4490287e67a2c391dfaea4d9359860281db3292b6886bf0be3d8692",
+                "sha256:35634369325906bcd01577da4c19e3b9541a15e99f31e91a02d010816b49bfda",
+                "sha256:35a8d1a24b5936b35c5003313bc177403d8bdef0f8b24f28b1c4a255f94ea992",
+                "sha256:3af5b4cc10fa41e5bc64e5c198a1b2d2864337f8fcbb9a67e747e34002ce812b",
+                "sha256:3bcce0edc1488906c2d4c75c94c70a0417e83920dd4c88fec1078c94843a6ce9",
+                "sha256:3c5b317ecbd8226887994852e85de562f7177add602514d4ac40f87de3ae45a8",
+                "sha256:3c6564c0947a7f52e4792983f8e6cf9bac140438ebf81f527a21d944f2fd0a40",
+                "sha256:3ebd879ab996537fc510a2be58c59915b5dd63bccb06d1ef514fee787e05984a",
+                "sha256:3f0b1798cae2bbbc9b9db44ee068c556d4737911ad53a4e5093d09d04b3bbc24",
+                "sha256:401ca1c4a20cc0510d3435d89c069fe0a9ae2ee6495135ac46bdd49ec0495763",
+                "sha256:454601988aab2c6e8fd49e7634c65476b2b919647626208e376afcd22019eeb8",
+                "sha256:4593c4eae9b27d22df41cde518b4b9e4464d139e4322e2127daa9b5b981b76be",
+                "sha256:45e484db65e5380804afbec784522de84fa95e6bb92ef1bd3325d33d13efaebd",
+                "sha256:48d64155d02127c249695abb87d39f0faf410733428d499867606be138161d65",
+                "sha256:4fbb0dbba559959fcb5d0735a0f87cdbca9e95dac87982e9b95c0f8f7ad10255",
+                "sha256:4fd52d3455a0aa997734f3835cbc4c9f32571345143960e7d7ebfe7b5fbfa3b2",
+                "sha256:50f2c501a89c9a5f4e454b126193c5495b9fb441a75b298c60591d8a2eb92e1b",
+                "sha256:58f77c60956501a4a627749a6dcb78dac522f249dd96b5c9f1c6af29bfacfb66",
+                "sha256:5a3ddb74b0985c4387719fc536faced33cadf2172769540c62e2a94b7b9be1c4",
+                "sha256:5c4a128527fe415d73cf1f70a9a688d06130d5810be69f3b553bf7b45e8acf79",
+                "sha256:5d473be2b13600b93a5675d78f59e63b51b1ba2d0476893415dfbb5477e65b31",
+                "sha256:5d9e40f32745db28c1ef7aad23f6fc458dc1e29945bd6781060f0d15628b8ddf",
+                "sha256:5f048bbf18b1f9120685c6d6bb70cc1a52c8cc11bdd04e643d28d3be0baf666d",
+                "sha256:605ffe7769e24b1800b4d024d24034405d9404f0bc2f55b6db3362cd34145a6f",
+                "sha256:6099263f526efff9cf3883dfef505518730f7a7a93049b1d90d42e50a22b4793",
+                "sha256:659d87430a8c8c704d52d094f5ba6fa72ef13b4d385b7e542a08fc240cb4a559",
+                "sha256:666fa7b1bd0a3810a7f18f6d3a25ccd8866291fbbc3c9b912b917a6715874bb9",
+                "sha256:68f6f060f0bbdfb0245267da014d3a6da9be127fe3e8cc4a68c6f833f8a23bb1",
+                "sha256:6d273f136e912aa101a9274c3145dcbddbe4bac560e77e6d5b3c9f6e0ed06d34",
+                "sha256:6d50841c425d16faf3206ddbba44c21aa3310a0cebc3c1cdfc3e3f4f9f6f5728",
+                "sha256:771c16060ff4e79584dc48902a91ba79fd93eade3aa3a12d6d2a4aadaf7d542b",
+                "sha256:785ffacd0ee61c3e60bdfde93baa6d7c10d86f15655bd706c89da08068dc5038",
+                "sha256:796ad874c89127c91970652a4ee8b00d56368b7e00d3477f4415fe78164c8000",
+                "sha256:79dc317a5f1c51fd9c6a0c4f48209c6b8526d0524a6904fc1076476e79b00f98",
+                "sha256:7c9409b47ba0650544b0bb3c188243b83654dfe55dcc173a86832314e1a6a35d",
+                "sha256:7d779b325cc8238227c47fbc53964c8cc9a941d5dbae87aa007a1f08f2f77b23",
+                "sha256:816568614ecb22b18a010c7a12559c19f6fe993526af88e95a76d5a60b8b75fb",
+                "sha256:8378fa4a940f3fb509c081e06cb7f7f2adae8cf46ef258b0e0ed7519facd573e",
+                "sha256:85608eb70a659bf4c1142b2781083d4b7c0c4e2c90eff11856a9754e965b2540",
+                "sha256:85fc223d9c76cabe5d0bff82214459189720dc135db45f9f66aa7cffbf9ff6c1",
+                "sha256:88ec04afe0c59fa64e2f6ea0dd9657e04fc83e38de90f6de201954b4d4eb59bd",
+                "sha256:8960b6dac09b62dac26e75d7e2c4a22efb835d827a7278c34f72b2b84fa160e3",
+                "sha256:89706d0683c73a26f76a5315d893c051324d771196ae8b13e6ffa1ffaf5e574f",
+                "sha256:89c24300cd4a8e4a51e55c31a8ff3918e6651b241ee8876a42cc2b2a078533ba",
+                "sha256:8c742af695f7525e559c16f1562cf2323db0e3f0fbdcabdf6865b095256b2d40",
+                "sha256:8dbd586bfa270c1103ece2109314dd423df1fa3d9719928b5d09e4840cec0d72",
+                "sha256:8eb8c84ecea987a2523e057c0d950bcb3f789696c0499290b8d7b3107a719d78",
+                "sha256:921954d7fbf3fccc7de8f717799304b14b6d9a45bbeec5a8d7408ccbf531faf5",
+                "sha256:9a46c2fb2545e21181445515960006e85d22025bd2fe6db23e76daec6eb689fe",
+                "sha256:9c006f3aadeda131b438c3092124bd196b66312f0caa5823ef09585a669cf449",
+                "sha256:9ceca1cf097ed77e1a51f1dbc8d174d10cb5931c188a4505ff9f3e119dfe519b",
+                "sha256:9e5fc7484fa7dce57e25063b0ec9638ff02a908304f861d81ea49273e43838c1",
+                "sha256:9f2f48ab00181600ee266a095fe815134eb456163f7d6699f525dee471f312cf",
+                "sha256:9fca84a15333e925dd59ce01da0ffe2ffe0d6e5d29a9eeba2148916d1824948c",
+                "sha256:a49e1d7a4978ed554f095430b89ecc23f42014a50ac385eb0c4d163ce213c325",
+                "sha256:a58d1ed49a94d4183483a3ce0af22f20318d4a1434acee255d683ad90bf78129",
+                "sha256:a61d0b2c7c9a0ae45732a77844917b427ff16ad5464b4d4f5e4adb955f582890",
+                "sha256:a714bf6e5e81b0e570d01f56e0c89c6375101b8463999ead3a93a5d2a4af91fa",
+                "sha256:a7b74e92a3b212390bdce1d93da9f6488c3878c1d434c5e751cbc202c5e09500",
+                "sha256:a8bd2f19e312ce3e1d2c635618e8a8d8132892bb746a7cf74780a489f0f6cdcb",
+                "sha256:b0be9965f93c222fb9b4cc254235b3b2b215796c03ef5ee64f995b1b69af0762",
+                "sha256:b24bf3cd93d5b6ecfbedec73b15f143596c88ee249fa98cefa9a9dc9d92c6f28",
+                "sha256:b5ffe453cde61f73fea9430223c81d29e2fbf412a6073951102146c84e19e34c",
+                "sha256:bc120d1132cff853ff617754196d0ac0ae63befe7c8498bd67731ba368abe451",
+                "sha256:bd035756830c712b64725a76327ce80e82ed12ebab361d3a1cdc0f51ea21acb0",
+                "sha256:bffcf57826d77a4151962bf1701374e0fc87f536e56ec46f1abdd6a903354042",
+                "sha256:c2013ee878c76269c7b557a9a9c042335d732e89d482606990b70a839635feb7",
+                "sha256:c4feb9211d15d9160bc85fa72fed46432cdc143eb9cf6d5ca377335a921ac37b",
+                "sha256:c8980cde3bb8575e7c956a530f2c217c1d6aac453474bf3ea0f9c89868b531b6",
+                "sha256:c98f126c4fc697b84c423e387337d5b07e4a61e9feac494362a59fd7a2d9ed80",
+                "sha256:ccc6f3ddef93243538be76f8e47045b4aad7a66a212cd3a0f23e34469473d36b",
+                "sha256:ccfa689b9246c48947d31dd9d8b16d89a0ecc8e0e26ea5253068efb6c542b76e",
+                "sha256:cda776f1967cb304816173b30994faaf2fd5bcb37e73118a47964a02c348e1bc",
+                "sha256:ce4c8e485a3c59593f1a6f683cf0ea5ab1c1dc94d11eea5619e4fb5228b40fbd",
+                "sha256:d3c10228d6cf6fe2b63d2e7985e94f6916fa46940df46b70449e9ff9297bd3d1",
+                "sha256:d4ca54b9cf9d80b4016a67a0193ebe0bcf29f6b0a96f09db942087e294d3d4c2",
+                "sha256:d4cb2b3ddc16710548801c6fcc0cfcdeeff9dafbc983f77265877793f2660309",
+                "sha256:d50e4864498a9ab639d6d8854b25e80642bd362ff104312d9770b05d66e5fb13",
+                "sha256:d74ec9bc0e2feb81d3f16946b005748119c0f52a153f6db6a29e8cd68636f295",
+                "sha256:d8222acdb51a22929c3b2ddb236b69c59c72af4019d2cba961e2f9add9b6e634",
+                "sha256:db58483f71c5db67d643857404da360dce3573031586034b7d59f245144cc192",
+                "sha256:dc3c1ff0abc91444cd20ec643d0f805df9a3661fcacf9c95000329f3ddf268a4",
+                "sha256:dd326a81afe332ede08eb39ab75b301d5676802cdffd3a8f287a5f0b694dc3f5",
+                "sha256:dec21e02e6cc932538b5203d3a8bd6aa1480c98c4914cb88eea064ecdbc6396a",
+                "sha256:e1dafef8df605fdb46edcc0bf1573dea0d6d7b01ba87f85cd04dc855b2b4479e",
+                "sha256:e2f6a2347d3440ae789505693a02836383426249d5293541cd712e07e7aecf54",
+                "sha256:e37caa8cdb3b7cf24786451a0bdb853f6347b8b92005eeb64225ae1db54d1c2b",
+                "sha256:e43a005671a9ed5a650f3bc39e4dbccd6d4326b24fb5ea8be5f3a43a6f576c72",
+                "sha256:e5e2f7280d8d0d3ef06f3ec1b4fd598d386cc6f0721e54f09109a8132182fbfe",
+                "sha256:e87798852ae0b37c88babb7f7bbbb3e3fecc562a1c340195b44c7e24d403e380",
+                "sha256:ee86d81551ec68a5c25373c5643d343150cc54672b5e9a0cafc93c1870a53954",
+                "sha256:f251bf23deb8332823aef1da169d5d89fa84c89f67bdfb566c49dea1fccfd50d",
+                "sha256:f3d86373ff19ca0441ebeb696ef64cb58b8b5cbacffcda5a0ec2f3911732a194",
+                "sha256:f4ad628b5174d5315761b67f212774a32f5bad5e61396d38108bd801c0a8f5d9",
+                "sha256:f70316f760174ca04492b5ab01be631a8ae30cadab1d1081035136ba12738cfa",
+                "sha256:f73ce1512e04fbe2bc97836e89830d6b4314c171587a99688082d090f934d20a",
+                "sha256:ff7c23ba0a88cb7b104281a99476cccadf29de2a0ef5ce864959a52675b1ca83"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==0.25.1"
         },
         "s3transfer": {
             "hashes": [
@@ -353,7 +509,7 @@
                 "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
                 "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.17.0"
         },
         "smart-open": {
@@ -382,6 +538,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==0.13.0"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4",
+                "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af"
+            ],
+            "markers": "python_version < '3.13'",
+            "version": "==4.14.0"
         },
         "tzdata": {
             "hashes": [
@@ -486,6 +650,14 @@
         }
     },
     "develop": {
+        "attrs": {
+            "hashes": [
+                "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3",
+                "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==25.3.0"
+        },
         "black": {
             "hashes": [
                 "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171",
@@ -908,7 +1080,6 @@
                 "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2",
                 "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de"
             ],
-            "markers": "python_version >= '3.9'",
             "version": "==3.18.0"
         },
         "freezegun": {
@@ -1375,7 +1546,7 @@
                 "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
                 "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.9.0.post0"
         },
         "pyyaml": {
@@ -1437,6 +1608,14 @@
             "markers": "python_version >= '3.8'",
             "version": "==6.0.2"
         },
+        "referencing": {
+            "hashes": [
+                "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa",
+                "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==0.36.2"
+        },
         "requests": {
             "hashes": [
                 "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c",
@@ -1460,6 +1639,129 @@
             ],
             "markers": "python_full_version >= '3.8.0'",
             "version": "==14.0.0"
+        },
+        "rpds-py": {
+            "hashes": [
+                "sha256:0317177b1e8691ab5879f4f33f4b6dc55ad3b344399e23df2e499de7b10a548d",
+                "sha256:036ded36bedb727beeabc16dc1dad7cb154b3fa444e936a03b67a86dc6a5066e",
+                "sha256:048893e902132fd6548a2e661fb38bf4896a89eea95ac5816cf443524a85556f",
+                "sha256:0701942049095741a8aeb298a31b203e735d1c61f4423511d2b1a41dcd8a16da",
+                "sha256:083a9513a33e0b92cf6e7a6366036c6bb43ea595332c1ab5c8ae329e4bcc0a9c",
+                "sha256:09eab132f41bf792c7a0ea1578e55df3f3e7f61888e340779b06050a9a3f16e9",
+                "sha256:0e6a327af8ebf6baba1c10fadd04964c1965d375d318f4435d5f3f9651550f4a",
+                "sha256:0eb90e94f43e5085623932b68840b6f379f26db7b5c2e6bcef3179bd83c9330f",
+                "sha256:114a07e85f32b125404f28f2ed0ba431685151c037a26032b213c882f26eb908",
+                "sha256:115874ae5e2fdcfc16b2aedc95b5eef4aebe91b28e7e21951eda8a5dc0d3461b",
+                "sha256:140f61d9bed7839446bdd44852e30195c8e520f81329b4201ceead4d64eb3a9f",
+                "sha256:1521031351865e0181bc585147624d66b3b00a84109b57fcb7a779c3ec3772cd",
+                "sha256:1c0c434a53714358532d13539272db75a5ed9df75a4a090a753ac7173ec14e11",
+                "sha256:1d1fadd539298e70cac2f2cb36f5b8a65f742b9b9f1014dd4ea1f7785e2470bf",
+                "sha256:1de336a4b164c9188cb23f3703adb74a7623ab32d20090d0e9bf499a2203ad65",
+                "sha256:1ee3e26eb83d39b886d2cb6e06ea701bba82ef30a0de044d34626ede51ec98b0",
+                "sha256:245550f5a1ac98504147cba96ffec8fabc22b610742e9150138e5d60774686d7",
+                "sha256:2a40046a529cc15cef88ac5ab589f83f739e2d332cb4d7399072242400ed68c9",
+                "sha256:2c2cd1a4b0c2b8c5e31ffff50d09f39906fe351389ba143c195566056c13a7ea",
+                "sha256:2cb9e5b5e26fc02c8a4345048cd9998c2aca7c2712bd1b36da0c72ee969a3523",
+                "sha256:33358883a4490287e67a2c391dfaea4d9359860281db3292b6886bf0be3d8692",
+                "sha256:35634369325906bcd01577da4c19e3b9541a15e99f31e91a02d010816b49bfda",
+                "sha256:35a8d1a24b5936b35c5003313bc177403d8bdef0f8b24f28b1c4a255f94ea992",
+                "sha256:3af5b4cc10fa41e5bc64e5c198a1b2d2864337f8fcbb9a67e747e34002ce812b",
+                "sha256:3bcce0edc1488906c2d4c75c94c70a0417e83920dd4c88fec1078c94843a6ce9",
+                "sha256:3c5b317ecbd8226887994852e85de562f7177add602514d4ac40f87de3ae45a8",
+                "sha256:3c6564c0947a7f52e4792983f8e6cf9bac140438ebf81f527a21d944f2fd0a40",
+                "sha256:3ebd879ab996537fc510a2be58c59915b5dd63bccb06d1ef514fee787e05984a",
+                "sha256:3f0b1798cae2bbbc9b9db44ee068c556d4737911ad53a4e5093d09d04b3bbc24",
+                "sha256:401ca1c4a20cc0510d3435d89c069fe0a9ae2ee6495135ac46bdd49ec0495763",
+                "sha256:454601988aab2c6e8fd49e7634c65476b2b919647626208e376afcd22019eeb8",
+                "sha256:4593c4eae9b27d22df41cde518b4b9e4464d139e4322e2127daa9b5b981b76be",
+                "sha256:45e484db65e5380804afbec784522de84fa95e6bb92ef1bd3325d33d13efaebd",
+                "sha256:48d64155d02127c249695abb87d39f0faf410733428d499867606be138161d65",
+                "sha256:4fbb0dbba559959fcb5d0735a0f87cdbca9e95dac87982e9b95c0f8f7ad10255",
+                "sha256:4fd52d3455a0aa997734f3835cbc4c9f32571345143960e7d7ebfe7b5fbfa3b2",
+                "sha256:50f2c501a89c9a5f4e454b126193c5495b9fb441a75b298c60591d8a2eb92e1b",
+                "sha256:58f77c60956501a4a627749a6dcb78dac522f249dd96b5c9f1c6af29bfacfb66",
+                "sha256:5a3ddb74b0985c4387719fc536faced33cadf2172769540c62e2a94b7b9be1c4",
+                "sha256:5c4a128527fe415d73cf1f70a9a688d06130d5810be69f3b553bf7b45e8acf79",
+                "sha256:5d473be2b13600b93a5675d78f59e63b51b1ba2d0476893415dfbb5477e65b31",
+                "sha256:5d9e40f32745db28c1ef7aad23f6fc458dc1e29945bd6781060f0d15628b8ddf",
+                "sha256:5f048bbf18b1f9120685c6d6bb70cc1a52c8cc11bdd04e643d28d3be0baf666d",
+                "sha256:605ffe7769e24b1800b4d024d24034405d9404f0bc2f55b6db3362cd34145a6f",
+                "sha256:6099263f526efff9cf3883dfef505518730f7a7a93049b1d90d42e50a22b4793",
+                "sha256:659d87430a8c8c704d52d094f5ba6fa72ef13b4d385b7e542a08fc240cb4a559",
+                "sha256:666fa7b1bd0a3810a7f18f6d3a25ccd8866291fbbc3c9b912b917a6715874bb9",
+                "sha256:68f6f060f0bbdfb0245267da014d3a6da9be127fe3e8cc4a68c6f833f8a23bb1",
+                "sha256:6d273f136e912aa101a9274c3145dcbddbe4bac560e77e6d5b3c9f6e0ed06d34",
+                "sha256:6d50841c425d16faf3206ddbba44c21aa3310a0cebc3c1cdfc3e3f4f9f6f5728",
+                "sha256:771c16060ff4e79584dc48902a91ba79fd93eade3aa3a12d6d2a4aadaf7d542b",
+                "sha256:785ffacd0ee61c3e60bdfde93baa6d7c10d86f15655bd706c89da08068dc5038",
+                "sha256:796ad874c89127c91970652a4ee8b00d56368b7e00d3477f4415fe78164c8000",
+                "sha256:79dc317a5f1c51fd9c6a0c4f48209c6b8526d0524a6904fc1076476e79b00f98",
+                "sha256:7c9409b47ba0650544b0bb3c188243b83654dfe55dcc173a86832314e1a6a35d",
+                "sha256:7d779b325cc8238227c47fbc53964c8cc9a941d5dbae87aa007a1f08f2f77b23",
+                "sha256:816568614ecb22b18a010c7a12559c19f6fe993526af88e95a76d5a60b8b75fb",
+                "sha256:8378fa4a940f3fb509c081e06cb7f7f2adae8cf46ef258b0e0ed7519facd573e",
+                "sha256:85608eb70a659bf4c1142b2781083d4b7c0c4e2c90eff11856a9754e965b2540",
+                "sha256:85fc223d9c76cabe5d0bff82214459189720dc135db45f9f66aa7cffbf9ff6c1",
+                "sha256:88ec04afe0c59fa64e2f6ea0dd9657e04fc83e38de90f6de201954b4d4eb59bd",
+                "sha256:8960b6dac09b62dac26e75d7e2c4a22efb835d827a7278c34f72b2b84fa160e3",
+                "sha256:89706d0683c73a26f76a5315d893c051324d771196ae8b13e6ffa1ffaf5e574f",
+                "sha256:89c24300cd4a8e4a51e55c31a8ff3918e6651b241ee8876a42cc2b2a078533ba",
+                "sha256:8c742af695f7525e559c16f1562cf2323db0e3f0fbdcabdf6865b095256b2d40",
+                "sha256:8dbd586bfa270c1103ece2109314dd423df1fa3d9719928b5d09e4840cec0d72",
+                "sha256:8eb8c84ecea987a2523e057c0d950bcb3f789696c0499290b8d7b3107a719d78",
+                "sha256:921954d7fbf3fccc7de8f717799304b14b6d9a45bbeec5a8d7408ccbf531faf5",
+                "sha256:9a46c2fb2545e21181445515960006e85d22025bd2fe6db23e76daec6eb689fe",
+                "sha256:9c006f3aadeda131b438c3092124bd196b66312f0caa5823ef09585a669cf449",
+                "sha256:9ceca1cf097ed77e1a51f1dbc8d174d10cb5931c188a4505ff9f3e119dfe519b",
+                "sha256:9e5fc7484fa7dce57e25063b0ec9638ff02a908304f861d81ea49273e43838c1",
+                "sha256:9f2f48ab00181600ee266a095fe815134eb456163f7d6699f525dee471f312cf",
+                "sha256:9fca84a15333e925dd59ce01da0ffe2ffe0d6e5d29a9eeba2148916d1824948c",
+                "sha256:a49e1d7a4978ed554f095430b89ecc23f42014a50ac385eb0c4d163ce213c325",
+                "sha256:a58d1ed49a94d4183483a3ce0af22f20318d4a1434acee255d683ad90bf78129",
+                "sha256:a61d0b2c7c9a0ae45732a77844917b427ff16ad5464b4d4f5e4adb955f582890",
+                "sha256:a714bf6e5e81b0e570d01f56e0c89c6375101b8463999ead3a93a5d2a4af91fa",
+                "sha256:a7b74e92a3b212390bdce1d93da9f6488c3878c1d434c5e751cbc202c5e09500",
+                "sha256:a8bd2f19e312ce3e1d2c635618e8a8d8132892bb746a7cf74780a489f0f6cdcb",
+                "sha256:b0be9965f93c222fb9b4cc254235b3b2b215796c03ef5ee64f995b1b69af0762",
+                "sha256:b24bf3cd93d5b6ecfbedec73b15f143596c88ee249fa98cefa9a9dc9d92c6f28",
+                "sha256:b5ffe453cde61f73fea9430223c81d29e2fbf412a6073951102146c84e19e34c",
+                "sha256:bc120d1132cff853ff617754196d0ac0ae63befe7c8498bd67731ba368abe451",
+                "sha256:bd035756830c712b64725a76327ce80e82ed12ebab361d3a1cdc0f51ea21acb0",
+                "sha256:bffcf57826d77a4151962bf1701374e0fc87f536e56ec46f1abdd6a903354042",
+                "sha256:c2013ee878c76269c7b557a9a9c042335d732e89d482606990b70a839635feb7",
+                "sha256:c4feb9211d15d9160bc85fa72fed46432cdc143eb9cf6d5ca377335a921ac37b",
+                "sha256:c8980cde3bb8575e7c956a530f2c217c1d6aac453474bf3ea0f9c89868b531b6",
+                "sha256:c98f126c4fc697b84c423e387337d5b07e4a61e9feac494362a59fd7a2d9ed80",
+                "sha256:ccc6f3ddef93243538be76f8e47045b4aad7a66a212cd3a0f23e34469473d36b",
+                "sha256:ccfa689b9246c48947d31dd9d8b16d89a0ecc8e0e26ea5253068efb6c542b76e",
+                "sha256:cda776f1967cb304816173b30994faaf2fd5bcb37e73118a47964a02c348e1bc",
+                "sha256:ce4c8e485a3c59593f1a6f683cf0ea5ab1c1dc94d11eea5619e4fb5228b40fbd",
+                "sha256:d3c10228d6cf6fe2b63d2e7985e94f6916fa46940df46b70449e9ff9297bd3d1",
+                "sha256:d4ca54b9cf9d80b4016a67a0193ebe0bcf29f6b0a96f09db942087e294d3d4c2",
+                "sha256:d4cb2b3ddc16710548801c6fcc0cfcdeeff9dafbc983f77265877793f2660309",
+                "sha256:d50e4864498a9ab639d6d8854b25e80642bd362ff104312d9770b05d66e5fb13",
+                "sha256:d74ec9bc0e2feb81d3f16946b005748119c0f52a153f6db6a29e8cd68636f295",
+                "sha256:d8222acdb51a22929c3b2ddb236b69c59c72af4019d2cba961e2f9add9b6e634",
+                "sha256:db58483f71c5db67d643857404da360dce3573031586034b7d59f245144cc192",
+                "sha256:dc3c1ff0abc91444cd20ec643d0f805df9a3661fcacf9c95000329f3ddf268a4",
+                "sha256:dd326a81afe332ede08eb39ab75b301d5676802cdffd3a8f287a5f0b694dc3f5",
+                "sha256:dec21e02e6cc932538b5203d3a8bd6aa1480c98c4914cb88eea064ecdbc6396a",
+                "sha256:e1dafef8df605fdb46edcc0bf1573dea0d6d7b01ba87f85cd04dc855b2b4479e",
+                "sha256:e2f6a2347d3440ae789505693a02836383426249d5293541cd712e07e7aecf54",
+                "sha256:e37caa8cdb3b7cf24786451a0bdb853f6347b8b92005eeb64225ae1db54d1c2b",
+                "sha256:e43a005671a9ed5a650f3bc39e4dbccd6d4326b24fb5ea8be5f3a43a6f576c72",
+                "sha256:e5e2f7280d8d0d3ef06f3ec1b4fd598d386cc6f0721e54f09109a8132182fbfe",
+                "sha256:e87798852ae0b37c88babb7f7bbbb3e3fecc562a1c340195b44c7e24d403e380",
+                "sha256:ee86d81551ec68a5c25373c5643d343150cc54672b5e9a0cafc93c1870a53954",
+                "sha256:f251bf23deb8332823aef1da169d5d89fa84c89f67bdfb566c49dea1fccfd50d",
+                "sha256:f3d86373ff19ca0441ebeb696ef64cb58b8b5cbacffcda5a0ec2f3911732a194",
+                "sha256:f4ad628b5174d5315761b67f212774a32f5bad5e61396d38108bd801c0a8f5d9",
+                "sha256:f70316f760174ca04492b5ab01be631a8ae30cadab1d1081035136ba12738cfa",
+                "sha256:f73ce1512e04fbe2bc97836e89830d6b4314c171587a99688082d090f934d20a",
+                "sha256:ff7c23ba0a88cb7b104281a99476cccadf29de2a0ef5ce864959a52675b1ca83"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==0.25.1"
         },
         "ruff": {
             "hashes": [
@@ -1499,7 +1801,7 @@
                 "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
                 "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.17.0"
         },
         "sortedcontainers": {
@@ -1514,8 +1816,17 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.2"
+        },
+        "types-jsonschema": {
+            "hashes": [
+                "sha256:6a906b5ff73ac11c8d1e0b6c30a9693e1e4e1ab56c56c932b3a7e081b86d187b",
+                "sha256:7e28c64e0ae7980eeb158105b20663fc6a6b8f81d5f86ea6614aa0014417bd1e"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==4.24.0.20250528"
         },
         "types-pytz": {
             "hashes": [
@@ -1530,7 +1841,7 @@
                 "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4",
                 "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af"
             ],
-            "markers": "python_version >= '3.9'",
+            "markers": "python_version < '3.13'",
             "version": "==4.14.0"
         },
         "urllib3": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -26,12 +26,12 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:34c27d7317cadb62c0e9856e5d5aa0271ef47202d340584831048bc7ac904136",
-                "sha256:efe0aaa060f8fedd76e5c942055f051aee0432fc722d79d8830a9fd9db83593e"
+                "sha256:a43cad12c18607ae9addfc0a98366aae5762b1a4880529f82295b21473686433",
+                "sha256:fcef3e08513d276c97d72d5e7ab8f3ce9950170784b9b5cf4fab327cdb577503"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==1.38.36"
+            "version": "==1.38.40"
         },
         "boto3-stubs": {
             "extras": [
@@ -39,19 +39,19 @@
                 "ses"
             ],
             "hashes": [
-                "sha256:1f79b85f93772df94854e9e570a917f1d762f4080a88ed16b9f2e4b98b24f1f1",
-                "sha256:8de916b9433e9224f3bd4a79ed41e508dc532bfee7db34bfd3752901bcd7e69f"
+                "sha256:401c51aa07c96df4b5452f37a2af3936c21b97cea0e68cddda9977a9f864d110",
+                "sha256:cf8cf0f67aa6aac0caa6cdcd78609c182cdc12727a67bd811dd8a95d03fa6c8f"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.38.36"
+            "version": "==1.38.40"
         },
         "botocore": {
             "hashes": [
-                "sha256:4a1ced1a4218bdff0ed5b46abb54570d473154ddefafa5d121a8d96e4b76ebc1",
-                "sha256:b6a50b853f6d23af9edfed89a59800c6bc1687a947cdd3492879f7d64e002d30"
+                "sha256:7528f47945502bf4226e629337c2ac2e454e661ac8fd1dc0fbf7f38082930f3f",
+                "sha256:aefbfe835a7ebe9bbdd88df3999b0f8f484dd025af4ebb3f3387541316ce4349"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.38.36"
+            "version": "==1.38.40"
         },
         "botocore-stubs": {
             "hashes": [
@@ -63,11 +63,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6",
-                "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3"
+                "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057",
+                "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2025.4.26"
+            "markers": "python_version >= '3.7'",
+            "version": "==2025.6.15"
         },
         "click": {
             "hashes": [
@@ -184,6 +184,7 @@
                 "sha256:1016508783c1263aba9bb24dd29afbea6f0c8c7cee79e9d073c4ed5524ce53f5",
                 "sha256:f4185231faab97bfb50b25dc1323333c630a092ffa8c15356f21116fc92a7f42"
             ],
+            "markers": "python_version >= '3.8'",
             "version": "==1.38.31"
         },
         "mypy-boto3-dynamodb": {
@@ -191,6 +192,7 @@
                 "sha256:5cf3787631e312b3d75f89a6cbbbd4ad786a76f5d565af023febf03fbf23c0b5",
                 "sha256:6b29d89c649eeb1e894118bee002cb8b1304c78da735b1503aa08e46b0abfdec"
             ],
+            "markers": "python_version >= '3.8'",
             "version": "==1.38.4"
         },
         "mypy-boto3-ec2": {
@@ -198,34 +200,39 @@
                 "sha256:5d07fc10d5f682f8570000ba53bdec00ee498171509943877451c2cccbc341a3",
                 "sha256:9750403a6ad135e676ecc280acee9f0d7762f46c5bc8d864ec7c2ad3ef6118b7"
             ],
+            "markers": "python_version >= '3.8'",
             "version": "==1.38.33"
         },
         "mypy-boto3-lambda": {
             "hashes": [
-                "sha256:0dcb882826f61fd2751f6b98330b0e11085570654db85318aea018374ca88dc9",
-                "sha256:ece7b3848c045e1be81c4f2b7482002c17ce7cb70de850661146103a8cb1a3fb"
+                "sha256:04bd5f4ad032f86cd0d5b8f573c0384a388dc8549ea6bb648dcef5b2c6664064",
+                "sha256:145c9f7de2da29fb651b21515c9052697f7579c821ee3ab7bcbf7ef4993dcd25"
             ],
-            "version": "==1.38.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.38.40"
         },
         "mypy-boto3-rds": {
             "hashes": [
                 "sha256:46ceae368e950936d8092a71408f09b001bebb94c57600aa1f0ae42525f51d85",
                 "sha256:4888ecaf09c42365e76af3e7f931c7924ccea83341d4268f400b352bcf340e7c"
             ],
+            "markers": "python_version >= '3.8'",
             "version": "==1.38.35"
         },
         "mypy-boto3-s3": {
             "hashes": [
-                "sha256:1129d64be1aee863e04f0c92ac8d315578f13ccae64fa199b20ad0950d2b9616",
-                "sha256:38a45dee5782d5c07ddea07ea50965c4d2ba7e77617c19f613b4c9f80f961b52"
+                "sha256:9b003a3d4f4e01c6f3a7dc01e6bdcf9cc58e74c48cfbccd7cf80328b5b3ef4c7",
+                "sha256:b272d1c9b359017ea7c5d79b4610ba93e91f557ad01da0d6e302bd7b7804f73b"
             ],
-            "version": "==1.38.26"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.38.39"
         },
         "mypy-boto3-ses": {
             "hashes": [
                 "sha256:1741e3cbace8454b121d93d22d49c8238be955eb9db602f6561d4222a6e3df30",
                 "sha256:e4fb4785caea4743dedbb0827bc697ec43bf674311d5cdef6b5e09abc5a230b5"
             ],
+            "markers": "python_version >= '3.8'",
             "version": "==1.38.0"
         },
         "mypy-boto3-sqs": {
@@ -233,6 +240,7 @@
                 "sha256:39aebc121a2fe20f962fd83b617fd916003605d6f6851fdf195337a0aa428fe1",
                 "sha256:8e881c8492f6f51dcbe1cce9d9f05334f4b256b5843e227fa925e0f6e702b31d"
             ],
+            "markers": "python_version >= '3.8'",
             "version": "==1.38.0"
         },
         "numpy": {
@@ -289,7 +297,7 @@
                 "sha256:f14e016d9409680959691c109be98c436c6249eaf7f118b424679793607b5944",
                 "sha256:f420033a20b4f6a2a11f585f93c843ac40686a7c3fa514060a97d9de93e5e72b"
             ],
-            "markers": "python_version >= '3.12'",
+            "markers": "python_version >= '3.11'",
             "version": "==2.3.0"
         },
         "pandas": {
@@ -544,7 +552,7 @@
                 "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4",
                 "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af"
             ],
-            "markers": "python_version < '3.13'",
+            "markers": "python_version >= '3.9'",
             "version": "==4.14.0"
         },
         "tzdata": {
@@ -557,11 +565,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466",
-                "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"
+                "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760",
+                "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==2.4.0"
+            "version": "==2.5.0"
         },
         "wrapt": {
             "hashes": [
@@ -696,20 +704,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:34c27d7317cadb62c0e9856e5d5aa0271ef47202d340584831048bc7ac904136",
-                "sha256:efe0aaa060f8fedd76e5c942055f051aee0432fc722d79d8830a9fd9db83593e"
+                "sha256:a43cad12c18607ae9addfc0a98366aae5762b1a4880529f82295b21473686433",
+                "sha256:fcef3e08513d276c97d72d5e7ab8f3ce9950170784b9b5cf4fab327cdb577503"
             ],
-            "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==1.38.36"
+            "version": "==1.38.40"
         },
         "botocore": {
             "hashes": [
-                "sha256:4a1ced1a4218bdff0ed5b46abb54570d473154ddefafa5d121a8d96e4b76ebc1",
-                "sha256:b6a50b853f6d23af9edfed89a59800c6bc1687a947cdd3492879f7d64e002d30"
+                "sha256:7528f47945502bf4226e629337c2ac2e454e661ac8fd1dc0fbf7f38082930f3f",
+                "sha256:aefbfe835a7ebe9bbdd88df3999b0f8f484dd025af4ebb3f3387541316ce4349"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.38.36"
+            "version": "==1.38.40"
         },
         "cachecontrol": {
             "extras": [
@@ -724,11 +731,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6",
-                "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3"
+                "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057",
+                "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2025.4.26"
+            "markers": "python_version >= '3.7'",
+            "version": "==2025.6.15"
         },
         "cffi": {
             "hashes": [
@@ -800,7 +807,7 @@
                 "sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87",
                 "sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b"
             ],
-            "markers": "platform_python_implementation != 'PyPy'",
+            "markers": "python_version >= '3.8'",
             "version": "==1.17.1"
         },
         "cfgv": {
@@ -914,7 +921,6 @@
                 "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202",
                 "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"
             ],
-            "index": "pypi",
             "markers": "python_version >= '3.10'",
             "version": "==8.2.1"
         },
@@ -1080,6 +1086,7 @@
                 "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2",
                 "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de"
             ],
+            "markers": "python_version >= '3.9'",
             "version": "==3.18.0"
         },
         "freezegun": {
@@ -1120,7 +1127,6 @@
                 "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d",
                 "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"
             ],
-            "index": "pypi",
             "markers": "python_version >= '3.7'",
             "version": "==3.1.6"
         },
@@ -1225,12 +1231,12 @@
         },
         "moto": {
             "hashes": [
-                "sha256:42b362ea9a16181e8e7b615ac212c294b882f020e9ae02f01230f167926df84e",
-                "sha256:866ae85eb5efe11a78f991127531878fd7f49177eb4a6680f47060430eb8932d"
+                "sha256:baf7afa9d4a92f07277b29cf466d0738f25db2ed2ee12afcb1dc3f2c540beebd",
+                "sha256:e4a3092bc8fe9139caa77cd34cdcbad804de4d9671e2270ea3b4d53f5c645047"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==5.1.5"
+            "version": "==5.1.6"
         },
         "msgpack": {
             "hashes": [
@@ -1299,42 +1305,42 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:021a68568082c5b36e977d54e8f1de978baf401a33884ffcea09bd8e88a98f4c",
-                "sha256:089bedc02307c2548eb51f426e085546db1fa7dd87fbb7c9fa561575cf6eb1ff",
-                "sha256:09a8da6a0ee9a9770b8ff61b39c0bb07971cda90e7297f4213741b48a0cc8d93",
-                "sha256:0b07e107affb9ee6ce1f342c07f51552d126c32cd62955f59a7db94a51ad12c0",
-                "sha256:15486beea80be24ff067d7d0ede673b001d0d684d0095803b3e6e17a886a2a92",
-                "sha256:29e1499864a3888bca5c1542f2d7232c6e586295183320caa95758fc84034031",
-                "sha256:2e7e0ad35275e02797323a5aa1be0b14a4d03ffdb2e5f2b0489fa07b89c67b21",
-                "sha256:4086883a73166631307fdd330c4a9080ce24913d4f4c5ec596c601b3a4bdd777",
-                "sha256:54066fed302d83bf5128632d05b4ec68412e1f03ef2c300434057d66866cea4b",
-                "sha256:55f9076c6ce55dd3f8cd0c6fff26a008ca8e5131b89d5ba6d86bd3f47e736eeb",
-                "sha256:6a2322896003ba66bbd1318c10d3afdfe24e78ef12ea10e2acd985e9d684a666",
-                "sha256:7909541fef256527e5ee9c0a7e2aeed78b6cda72ba44298d1334fe7881b05c5c",
-                "sha256:82d056e6faa508501af333a6af192c700b33e15865bda49611e3d7d8358ebea2",
-                "sha256:84b94283f817e2aa6350a14b4a8fb2a35a53c286f97c9d30f53b63620e7af8ab",
-                "sha256:936ccfdd749af4766be824268bfe22d1db9eb2f34a3ea1d00ffbe5b5265f5491",
-                "sha256:9f826aaa7ff8443bac6a494cf743f591488ea940dd360e7dd330e30dd772a5ab",
-                "sha256:a5fcfdb7318c6a8dd127b14b1052743b83e97a970f0edb6c913211507a255e20",
-                "sha256:a7e32297a437cc915599e0578fa6bc68ae6a8dc059c9e009c628e1c47f91495d",
-                "sha256:a9e056237c89f1587a3be1a3a70a06a698d25e2479b9a2f57325ddaaffc3567b",
-                "sha256:afe420c9380ccec31e744e8baff0d406c846683681025db3531b32db56962d52",
-                "sha256:b4968f14f44c62e2ec4a038c8797a87315be8df7740dc3ee8d3bfe1c6bf5dba8",
-                "sha256:bd4e1ebe126152a7bbaa4daedd781c90c8f9643c79b9748caa270ad542f12bec",
-                "sha256:c5436d11e89a3ad16ce8afe752f0f373ae9620841c50883dc96f8b8805620b13",
-                "sha256:c6fb60cbd85dc65d4d63d37cb5c86f4e3a301ec605f606ae3a9173e5cf34997b",
-                "sha256:d045d33c284e10a038f5e29faca055b90eee87da3fc63b8889085744ebabb5a1",
-                "sha256:e71d6f0090c2256c713ed3d52711d01859c82608b5d68d4fa01a3fe30df95571",
-                "sha256:eb14a4a871bb8efb1e4a50360d4e3c8d6c601e7a31028a2c79f9bb659b63d730",
-                "sha256:eb5fbc8063cb4fde7787e4c0406aa63094a34a2daf4673f359a1fb64050e9cb2",
-                "sha256:f2622af30bf01d8fc36466231bdd203d120d7a599a6d88fb22bdcb9dbff84090",
-                "sha256:f2ed0e0847a80655afa2c121835b848ed101cc7b8d8d6ecc5205aedc732b1436",
-                "sha256:f56236114c425620875c7cf71700e3d60004858da856c6fc78998ffe767b73d3",
-                "sha256:feec38097f71797da0231997e0de3a58108c51845399669ebc532c815f93866b"
+                "sha256:051e1677689c9d9578b9c7f4d206d763f9bbd95723cd1416fad50db49d52f359",
+                "sha256:08e850ea22adc4d8a4014651575567b0318ede51e8e9fe7a68f25391af699507",
+                "sha256:09aa4f91ada245f0a45dbc47e548fd94e0dd5a8433e0114917dc3b526912a30c",
+                "sha256:0a7cfb0fe29fe5a9841b7c8ee6dffb52382c45acdf68f032145b75620acfbd6f",
+                "sha256:0ab5eca37b50188163fa7c1b73c685ac66c4e9bdee4a85c9adac0e91d8895e15",
+                "sha256:1256688e284632382f8f3b9e2123df7d279f603c561f099758e66dd6ed4e8bd6",
+                "sha256:13c7cd5b1cb2909aa318a90fd1b7e31f17c50b242953e7dd58345b2a814f6383",
+                "sha256:1f0435cf920e287ff68af3d10a118a73f212deb2ce087619eb4e648116d1fe9b",
+                "sha256:211287e98e05352a2e1d4e8759c5490925a7c784ddc84207f4714822f8cf99b6",
+                "sha256:22d76a63a42619bfb90122889b903519149879ddbf2ba4251834727944c8baca",
+                "sha256:2c7ce0662b6b9dc8f4ed86eb7a5d505ee3298c04b40ec13b30e572c0e5ae17c4",
+                "sha256:352025753ef6a83cb9e7f2427319bb7875d1fdda8439d1e23de12ab164179574",
+                "sha256:44e7acddb3c48bd2713994d098729494117803616e116032af192871aed80b79",
+                "sha256:472e4e4c100062488ec643f6162dd0d5208e33e2f34544e1fc931372e806c0cc",
+                "sha256:4f58ac32771341e38a853c5d0ec0dfe27e18e27da9cdb8bbc882d2249c71a3ee",
+                "sha256:58e07fb958bc5d752a280da0e890c538f1515b79a65757bbdc54252ba82e0b40",
+                "sha256:5e198ab3f55924c03ead626ff424cad1732d0d391478dfbf7bb97b34602395da",
+                "sha256:5fc2ac4027d0ef28d6ba69a0343737a23c4d1b83672bf38d1fe237bdc0643b37",
+                "sha256:66df38405fd8466ce3517eda1f6640611a0b8e70895e2a9462d1d4323c5eb4b9",
+                "sha256:6bd00a0a2094841c5e47e7374bb42b83d64c527a502e3334e1173a0c24437bab",
+                "sha256:7fc688329af6a287567f45cc1cefb9db662defeb14625213a5b7da6e692e2069",
+                "sha256:86042bbf9f5a05ea000d3203cf87aa9d0ccf9a01f73f71c58979eb9249f46d72",
+                "sha256:87ff2c13d58bdc4bbe7dc0dedfe622c0f04e2cb2a492269f3b418df2de05c536",
+                "sha256:af4792433f09575d9eeca5c63d7d90ca4aeceda9d8355e136f80f8967639183d",
+                "sha256:b4f0fed1022a63c6fec38f28b7fc77fca47fd490445c69d0a66266c59dd0b88a",
+                "sha256:d5d2309511cc56c021b4b4e462907c2b12f669b2dbeb68300110ec27723971be",
+                "sha256:ddc91eb318c8751c69ddb200a5937f1232ee8efb4e64e9f4bc475a33719de438",
+                "sha256:dedb6229b2c9086247e21a83c309754b9058b438704ad2f6807f0d8227f6ebdd",
+                "sha256:ea16e2a7d2714277e349e24d19a782a663a34ed60864006e8585db08f8ad1782",
+                "sha256:ea7469ee5902c95542bea7ee545f7006508c65c8c54b06dc2c92676ce526f3ea",
+                "sha256:f895078594d918f93337a505f8add9bd654d1a24962b4c6ed9390e12531eb31b",
+                "sha256:ff9fa5b16e4c1364eb89a4d16bcda9987f05d39604e1e6c35378a2987c1aac2d"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==1.16.0"
+            "version": "==1.16.1"
         },
         "mypy-extensions": {
             "hashes": [
@@ -1406,7 +1412,7 @@
                 "sha256:f14e016d9409680959691c109be98c436c6249eaf7f118b424679793607b5944",
                 "sha256:f420033a20b4f6a2a11f585f93c843ac40686a7c3fa514060a97d9de93e5e72b"
             ],
-            "markers": "python_version >= '3.12'",
+            "markers": "python_version >= '3.11'",
             "version": "==2.3.0"
         },
         "packageurl-python": {
@@ -1534,12 +1540,12 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6",
-                "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e"
+                "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7",
+                "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==8.4.0"
+            "version": "==8.4.1"
         },
         "python-dateutil": {
             "hashes": [
@@ -1765,28 +1771,28 @@
         },
         "ruff": {
             "hashes": [
-                "sha256:1808b3ed53e1a777c2ef733aca9051dc9bf7c99b26ece15cb59a0320fbdbd629",
-                "sha256:26816a218ca6ef02142343fd24c70f7cd8c5aa6c203bca284407adf675984432",
-                "sha256:26fa247dc68d1d4e72c179e08889a25ac0c7ba4d78aecfc835d49cbfd60bf514",
-                "sha256:29c3189895a8a6a657b7af4e97d330c8a3afd2c9c8f46c81e2fc5a31866517e3",
-                "sha256:4a9ddd3ec62a9a89578c85842b836e4ac832d4a2e0bfaad3b02243f930ceafcc",
-                "sha256:4bdfbf1240533f40042ec00c9e09a3aade6f8c10b6414cf11b519488d2635d46",
-                "sha256:4ffbc82d70424b275b089166310448051afdc6e914fdab90e08df66c43bb5ca9",
-                "sha256:51c3f95abd9331dc5b87c47ac7f376db5616041173826dfd556cfe3d4977f492",
-                "sha256:53b15a9dfdce029c842e9a5aebc3855e9ab7771395979ff85b7c1dedb53ddc2b",
-                "sha256:55e4bc3a77842da33c16d55b32c6cac1ec5fb0fbec9c8c513bdce76c4f922165",
-                "sha256:633bf2c6f35678c56ec73189ba6fa19ff1c5e4807a78bf60ef487b9dd272cc71",
-                "sha256:6c51f93029d54a910d3d24f7dd0bb909e31b6cd989a5e4ac513f4eb41629f0dc",
-                "sha256:96c27935418e4e8e77a26bb05962817f28b8ef3843a6c6cc49d8783b5507f250",
-                "sha256:ab153241400789138d13f362c43f7edecc0edfffce2afa6a68434000ecd8f69a",
-                "sha256:aef9c9ed1b5ca28bb15c7eac83b8670cf3b20b478195bd49c8d756ba0a36cf48",
-                "sha256:b4385285e9179d608ff1d2fb9922062663c658605819a6876d8beef0c30b7f3b",
-                "sha256:d237a496e0778d719efb05058c64d28b757c77824e04ffe8796c7436e26712b7",
-                "sha256:d28ce58b5ecf0f43c1b71edffabe6ed7f245d5336b17805803312ec9bc665933"
+                "sha256:05ed0c914fabc602fc1f3b42c53aa219e5736cb030cdd85640c32dbc73da74a6",
+                "sha256:07a7aa9b69ac3fcfda3c507916d5d1bca10821fe3797d46bad10f2c6de1edda0",
+                "sha256:0c0758038f81beec8cc52ca22de9685b8ae7f7cc18c013ec2050012862cc9165",
+                "sha256:139b3d28027987b78fc8d6cfb61165447bdf3740e650b7c480744873688808c2",
+                "sha256:1e55e44e770e061f55a7dbc6e9aed47feea07731d809a3710feda2262d2d4d8a",
+                "sha256:3a9512af224b9ac4757f7010843771da6b2b0935a9e5e76bb407caa901a1a514",
+                "sha256:4d047db3662418d4a848a3fdbfaf17488b34b62f527ed6f10cb8afd78135bc5c",
+                "sha256:5652a9ecdb308a1754d96a68827755f28d5dfb416b06f60fd9e13f26191a8848",
+                "sha256:68853e8517b17bba004152aebd9dd77d5213e503a5f2789395b25f26acac0da4",
+                "sha256:6a315992297a7435a66259073681bb0d8647a826b7a6de45c6934b2ca3a9ed51",
+                "sha256:7162a4c816f8d1555eb195c46ae0bd819834d2a3f18f98cc63819a7b46f474fb",
+                "sha256:7d235618283718ee2fe14db07f954f9b2423700919dc688eacf3f8797a11315c",
+                "sha256:8cd24580405ad8c1cc64d61725bca091d6b6da7eb3d36f72cc605467069d7e8b",
+                "sha256:952d0630eae628250ab1c70a7fffb641b03e6b4a2d3f3ec6c1d19b4ab6c6c807",
+                "sha256:b08df3d96db798e5beb488d4df03011874aff919a97dcc2dd8539bb2be5d6a88",
+                "sha256:c021f04ea06966b02614d442e94071781c424ab8e02ec7af2f037b4c1e01cc82",
+                "sha256:d00b7a157b8fb6d3827b49d3324da34a1e3f93492c1f97b08e222ad7e9b291e0",
+                "sha256:e7731c3eec50af71597243bace7ec6104616ca56dda2b99c89935fe926bdcd48"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==0.11.13"
+            "version": "==0.12.0"
         },
         "s3transfer": {
             "hashes": [
@@ -1841,16 +1847,16 @@
                 "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4",
                 "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af"
             ],
-            "markers": "python_version < '3.13'",
+            "markers": "python_version >= '3.9'",
             "version": "==4.14.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466",
-                "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"
+                "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760",
+                "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==2.4.0"
+            "version": "==2.5.0"
         },
         "virtualenv": {
             "hashes": [

--- a/dsc/utilities/validate/schemas.py
+++ b/dsc/utilities/validate/schemas.py
@@ -1,0 +1,68 @@
+RESULT_MESSAGE_ATTRIBUTES = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "DSS Result Message - MessageAttributes",
+    "description": "Content of result message 'MessageAttributes' from DSS",
+    "type": "object",
+    "properties": {
+        "PackageID": {
+            "type": "object",
+            "properties": {
+                "DataType": {"type": "string", "const": "String"},
+                "StringValue": {"type": "string"},
+            },
+            "required": ["DataType", "StringValue"],
+        },
+        "SubmissionSource": {
+            "type": "object",
+            "properties": {
+                "DataType": {"type": "string", "const": "String"},
+                "StringValue": {"type": "string"},
+            },
+            "required": ["DataType", "StringValue"],
+        },
+    },
+    "required": ["PackageID", "SubmissionSource"],
+}
+
+RESULT_MESSAGE_BODY = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "DSS Result Message - Body",
+    "description": "Content of result message 'Body' from DSS",
+    "type": "object",
+    "properties": {
+        "ResultType": {"type": "string"},
+        "ItemHandle": {"type": "string"},
+        "lastModified": {"type": "string"},
+        "Bitstreams": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "BitstreamName": {"type": "string"},
+                    "BitstreamUUID": {"type": "string"},
+                    "BitstreamChecksum": {
+                        "type": "object",
+                        "properties": {
+                            "value": {"type": "string"},
+                            "checkSumAlgorithm": {"type": "string"},
+                        },
+                    },
+                },
+            },
+        },
+        "ErrorTimestamp": {"type": "string"},
+        "ErrorInfo": {"type": "string"},
+        "DSpaceResponse": {"type": "string"},
+        "ExceptionTraceback": {"type": "array", "items": {"type": "string"}},
+    },
+    "if": {"properties": {"ResultType": {"const": "success"}}},
+    "then": {"required": ["ItemHandle", "lastModified", "Bitstreams"]},
+    "else": {
+        "required": [
+            "ErrorTimestamp",
+            "ErrorInfo",
+            "DSpaceResponse",
+            "ExceptionTraceback",
+        ]
+    },
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -168,7 +168,6 @@ def test_finalize_success(
     )
     assert "Receiving messages from the queue 'mock-output-queue'" in caplog.text
     assert "Retrieved message" in caplog.text
-    assert "Parsed message" in caplog.text
     assert "No messages remain in the queue 'mock-output-queue'" in caplog.text
     assert json.dumps(expected_processing_summary) in caplog.text
     assert "Logs sent to ['test@test.test', 'test2@test.test']" in caplog.text

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -3,8 +3,6 @@ from http import HTTPStatus
 import pytest
 from botocore.exceptions import ClientError
 
-from dsc.exceptions import InvalidSQSMessageError
-
 
 def test_sqs_create_dss_message_attributes(sqs_client, submission_message_attributes):
     dss_message_attributes = sqs_client.create_dss_message_attributes(
@@ -108,73 +106,3 @@ def test_sqs_receive_nonexistent_queue_raises_error(mocked_sqs_output, sqs_clien
         "An error occurred (AWS.SimpleQueueService.NonExistentQueue) when calling "
         "the GetQueueUrl operation: The specified queue does not exist."
     )
-
-
-def test_sqs_parse_dss_result_message_success(
-    mocked_sqs_output, sqs_client, result_message_attributes, result_message_body
-):
-    sqs_client.send(
-        message_attributes=result_message_attributes,
-        message_body=result_message_body,
-    )
-    messages = sqs_client.receive()
-    identifier, message_body = sqs_client.parse_dss_result_message(
-        sqs_message=next(messages)
-    )
-    assert identifier == "10.1002/term.3131"
-    assert message_body["ItemHandle"] == "1721.1/131022"
-
-
-def test_sqs_parse_dss_result_message_invalid_message_raises_exception(
-    mocked_sqs_output,
-    sqs_client,
-):
-    sqs_client.send(message_attributes={}, message_body="")
-    messages = sqs_client.receive()
-    with pytest.raises(InvalidSQSMessageError):
-        sqs_client.parse_dss_result_message(
-            sqs_message=next(messages),
-        )
-
-
-def test_sqs_validate_dss_result_message_success(sqs_client, result_message_valid):
-    try:
-        sqs_client.validate_dss_result_message(sqs_message=result_message_valid)
-    except Exception:  # noqa: BLE001
-        pytest.fail("An exception was raised.")
-
-
-def test_sqs_validate_dss_result_message_no_receipt_handle_raises_error(
-    mocked_sqs_input, result_message_valid, sqs_client
-):
-    # message without 'ReceiptHandle' is invalid
-    result_message_invalid = dict(result_message_valid)
-    result_message_invalid["ReceiptHandle"] = None
-
-    with pytest.raises(
-        InvalidSQSMessageError, match="Failed to retrieve 'ReceiptHandle' from message"
-    ):
-        sqs_client.validate_dss_result_message(sqs_message=result_message_invalid)
-
-
-def test_sqs_validate_message_attributes_invalid_raises_error(
-    mocked_sqs_input, result_message_valid, sqs_client
-):
-    # message without 'MessageAttributes' is invalid
-    result_message_invalid = dict(result_message_valid)
-    result_message_invalid["MessageAttributes"] = {}
-
-    with pytest.raises(
-        InvalidSQSMessageError, match="Failed to parse message attributes"
-    ):
-        sqs_client.validate_message_attributes(sqs_message=result_message_invalid)
-
-
-def test_sqs_validate_message_body_invalid_raises_error(
-    mocked_sqs_input, result_message_valid, sqs_client
-):
-    result_message_invalid = dict(result_message_valid)
-    result_message_invalid["Body"] = "{}"
-
-    with pytest.raises(InvalidSQSMessageError, match="Failed to parse message body"):
-        sqs_client.validate_message_body(sqs_message=result_message_invalid)


### PR DESCRIPTION
### Purpose and background context

Refactor methods for processing result messages to clarify validation logic and “clear” invalid result messages from the output queue. While a JSON Schema may seem complex at first, the schema allows the app to keep all the "rules" re: the structure of result messages in a single place, which allows for the cleaner, simplified code in `Workflow._parse_result_message`. 

**Notes:** 
1. If possible, I'd like to postpone addressing any comments/suggestions regarding where the JSON schema should exist (e.g., "Does it belong in DSC") or how to improve the use of the JSON schema. For now, I think it is important to keep it simple and functional!

2. One of the key updates in this PR is [the creation of an object called `result_info`](https://github.com/MITLibraries/dspace-submission-composer/pull/176/files#diff-9409cf7165577c3250e707080466409d47908aae682829ddb8a1abadecda795aR374-R376), a dictionary to hold the parsed information from a result message. You may notice that there are no longer any calls to add error messages separately to `Workflow.workflow_events.errors` (see old versions of [line 372](https://github.com/MITLibraries/dspace-submission-composer/pull/176/files#diff-9409cf7165577c3250e707080466409d47908aae682829ddb8a1abadecda795aL372) and [line 396](https://github.com/MITLibraries/dspace-submission-composer/pull/176/files#diff-9409cf7165577c3250e707080466409d47908aae682829ddb8a1abadecda795aL396)). This is part of a concerted effort to [improve the structure of the `finalize` report via consolidating all results in a single _thing_](https://mitlibraries.atlassian.net/browse/IN-1320). There will be a separate PR that builds off the updates implemented here.

### How can a reviewer manually see the effects of these changes?

Review [updated unit tests](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1323-improve-methods-for-processing-result-messages/tests/test_workflow.py#L293-L396).

### Includes new or updated dependencies?
YES - Adds `jsonschema` to `[packages]`, `types-jsonschema` to `[dev-packages]`; ran `make update` to resolve linting errors.

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1323

### Developer
- [X] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

