### PR TITLE
Consolidate 'finalize' result summaries into a single file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,15 +74,13 @@ stop-minio-server:
 	docker compose --env-file .env -f $(MINIO_COMPOSE_FILE) stop
 
 ### Terraform-generated Developer Deploy Commands for Dev environment ###
-dist-dev:
-## Build docker container (intended for developer-based manual build)
-	docker build --platform linux/amd64 \\
-		-t $(ECR_URL_DEV):latest \\
-		-t $(ECR_URL_DEV):`git describe --always` \\
+dist-dev: ## Build docker container (intended for developer-based manual build)
+	docker build --platform linux/amd64 \
+		-t $(ECR_URL_DEV):latest \
+		-t $(ECR_URL_DEV):`git describe --always` \
 		-t $(ECR_NAME_DEV):latest .
 
-publish-dev: dist-dev
-## Build, tag and push (intended for developer-based manual publish)
+publish-dev: dist-dev ## Build, tag and push (intended for developer-based manual publish)
 	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_URL_DEV)
 	docker push $(ECR_URL_DEV):latest
 	docker push $(ECR_URL_DEV):`git describe --always`
@@ -98,9 +96,9 @@ publish-dev: dist-dev
 ### authenticated to the correct AWS Account. The values for the environment ###
 ### variables can be found in the stage_build.yml caller workflow. ###
 dist-stage: ## Only use in an emergency
-	docker build --platform linux/amd64 \\
-		-t $(ECR_URL_STAGE):latest \\
-		-t $(ECR_URL_STAGE):`git describe --always` \\
+	docker build --platform linux/amd64 \
+		-t $(ECR_URL_STAGE):latest \
+		-t $(ECR_URL_STAGE):`git describe --always` \
 		-t $(ECR_NAME_STAGE):latest .
 
 publish-stage: ## Only use in an emergency

--- a/dsc/reports/templates/html/finalize.html
+++ b/dsc/reports/templates/html/finalize.html
@@ -7,7 +7,9 @@
 <p>Run date: {{report_date}}</p>
 
 <p>Results:</p>
-<p>Processed: {{ processed_items|length }}</p>
-<p>Ingested: {{ ingested_items | length }}</p>
-<p>Errors: {{ errors|length }}</p>
+<ul>
+  {% for key, value in summary.items() %}
+    <li>{{ key }}: {{ value }}</li>
+  {% endfor %}
+</ul>
 {% endblock %}

--- a/dsc/reports/templates/plain_text/finalize.txt
+++ b/dsc/reports/templates/plain_text/finalize.txt
@@ -6,7 +6,7 @@ Batch: {{batch_id}}
 Run date: {{report_date}}
 
 Results:
-Processed: {{ processed_items|length }}
-Ingested: {{ ingested_items|length }}
-Errors: {{ errors|length }}
+{% for key, value in summary.items() %}
+{{ key }}: {{ value }}
+{% endfor %}
 {% endblock %}

--- a/dsc/workflows/base/__init__.py
+++ b/dsc/workflows/base/__init__.py
@@ -426,10 +426,10 @@ class Workflow(ABC):
         """
         result_info: dict = {
             "item_identifier": None,
-            "result_message_body": message_body,
             "ingested": None,
             "dspace_handle": None,
             "error": None,
+            "result_message_body": message_body,
         }
 
         # validate content of 'MessageAttributes'

--- a/dsc/workflows/base/__init__.py
+++ b/dsc/workflows/base/__init__.py
@@ -428,6 +428,7 @@ class Workflow(ABC):
             "item_identifier": None,
             "result_message_body": message_body,
             "ingested": None,
+            "dspace_handle": None,
             "error": None,
         }
 
@@ -460,6 +461,7 @@ class Workflow(ABC):
         else:
             result_info["ingested"] = bool(parsed_message_body["ResultType"] == "success")
             result_info["result_message_body"] = parsed_message_body
+            result_info["dspace_handle"] = parsed_message_body["ItemHandle"]
         return result_info
 
     def workflow_specific_processing(self, items: list[dict]) -> None:

--- a/dsc/workflows/base/__init__.py
+++ b/dsc/workflows/base/__init__.py
@@ -461,7 +461,7 @@ class Workflow(ABC):
         else:
             result_info["ingested"] = bool(parsed_message_body["ResultType"] == "success")
             result_info["result_message_body"] = parsed_message_body
-            result_info["dspace_handle"] = parsed_message_body["ItemHandle"]
+            result_info["dspace_handle"] = parsed_message_body.get("ItemHandle")
         return result_info
 
     def workflow_specific_processing(self, items: list[dict]) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -358,10 +358,10 @@ def workflow_events_finalize(result_message_body):
         processed_items=[
             {
                 "item_identifier": "123",
-                "result_message_body": json.loads(result_message_body),
                 "ingested": True,
                 "dspace_handle": None,
                 "error": None,
+                "result_message_body": json.loads(result_message_body),
             }
         ]
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -360,7 +360,8 @@ def workflow_events_finalize(result_message_body):
                 "item_identifier": "123",
                 "result_message_body": json.loads(result_message_body),
                 "ingested": True,
+                "dspace_handle": None,
+                "error": None,
             }
-        ],
-        errors=["Failed to retrieve 'ReceiptHandle' from message: abc"],
+        ]
     )

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -119,24 +119,15 @@ def test_finalize_report_subject_success(workflow_events_finalize):
     assert finalize_report.subject == "DSpace Submission Results - test, batch='aaa'"
 
 
-def test_finalize_report_create_attachments_success(
-    workflow_events_finalize,
-):
+def test_finalize_report_create_attachments_success(workflow_events_finalize):
     finalize_report = FinalizeReport(
         workflow_name="test", batch_id="aaa", events=workflow_events_finalize
     )
     attachments = finalize_report.create_attachments()
 
     ingested_items_filename, ingested_items_buffer = attachments[0]
-    assert ingested_items_filename == "ingested_items.csv"
-    assert ingested_items_buffer.readlines() == [
-        "item_identifier,dspace_handle\n",
-        "123,1721.1/131022\n",
-    ]
-
-    errors_filename, errors_buffer = attachments[1]
-    assert errors_filename == "errors.csv"
-    assert errors_buffer.readlines() == [
-        "error\n",
-        "Failed to retrieve 'ReceiptHandle' from message: abc\n",
-    ]
+    assert ingested_items_filename == "dss_submission_results.csv"
+    assert (
+        ingested_items_buffer.readlines()[0]
+        == "item_identifier,result_message_body,ingested,dspace_handle,error\n"
+    )

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -129,5 +129,5 @@ def test_finalize_report_create_attachments_success(workflow_events_finalize):
     assert ingested_items_filename == "dss_submission_results.csv"
     assert (
         ingested_items_buffer.readlines()[0]
-        == "item_identifier,result_message_body,ingested,dspace_handle,error\n"
+        == "item_identifier,ingested,dspace_handle,error,result_message_body\n"
     )

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -193,6 +193,7 @@ def test_base_workflow_process_sqs_queue_success(
                 "lastModified": "Thu Sep 09 17:56:39 UTC 2021",
             },
             "ingested": True,
+            "dspace_handle": "1721.1/131022",
             "error": None,
         }
     ]
@@ -304,6 +305,7 @@ def test_base_workflow_parse_result_message_success(
         "item_identifier": "10.1002/term.3131",
         "result_message_body": json.loads(message_body),
         "ingested": True,
+        "dspace_handle": "1721.1/131022",
         "error": None,
     }
 
@@ -325,6 +327,7 @@ def test_base_workflow_parse_result_message_attrs_if_jsonschema_validation_fails
         "item_identifier": None,
         "result_message_body": message_body,
         "ingested": None,
+        "dspace_handle": None,
         "error": "Content of 'MessageAttributes' is invalid",
     }
 
@@ -348,6 +351,7 @@ def test_base_workflow_parse_result_message_body_if_jsonschema_validation_fails(
         "item_identifier": "10.1002/term.3131",
         "result_message_body": json.dumps(modified_message_body),
         "ingested": None,
+        "dspace_handle": None,
         "error": "Content of 'Body' is invalid",
     }
 
@@ -366,6 +370,7 @@ def test_base_workflow_parse_result_message_body_if_invalid_json(
         "item_identifier": "10.1002/term.3131",
         "result_message_body": "",
         "ingested": None,
+        "dspace_handle": None,
         "error": "Failed to parse content of 'Body'",
     }
 
@@ -392,6 +397,7 @@ def test_base_workflow_parse_result_message_if_not_ingested(
         "item_identifier": "10.1002/term.3131",
         "result_message_body": message_body,
         "ingested": False,
+        "dspace_handle": None,
         "error": None,
     }
 


### PR DESCRIPTION
### Purpose and background context
Simplify generated report via 'finalize' by keeping all DSS results for a batch in a single file

**Note: DO NOT MERGE UNTIL PR #176 is approved and merged!** These changes build on the work in PR #176. 

### How can a reviewer manually see the effects of these changes?

A test run using a small sample of OpenCourseWare files was performed. The screenshot and file attachment shared below are from the email sent on June 16, 2025 at 10:24AM EST with subject heading: `DSpace Submission Results - opencourseware, batch='opencourseware-2025-04-22-stepfunctiontest'`.

1. Review screenshot of email sent via `finalize` command
<img width="745" alt="image" src="https://github.com/user-attachments/assets/b81e5cc7-44a8-4832-b58f-12cc75339e7e" />

2. Review file attachment: [dss_submission_results.csv](https://github.com/user-attachments/files/20759256/dss_submission_results.csv)

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- * https://mitlibraries.atlassian.net/browse/IN-1320

### Developer
- [x] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

