### PR TITLE
Update 'reconcile' command to use DynamoDB table

### DIFF
--- a/dsc/cli.py
+++ b/dsc/cli.py
@@ -5,6 +5,7 @@ from time import perf_counter
 import click
 
 from dsc.config import Config
+from dsc.db.models import ItemSubmissionDB
 from dsc.reports import FinalizeReport, ReconcileReport, SubmitReport
 from dsc.workflows.base import Workflow
 
@@ -47,6 +48,7 @@ def main(
     CONFIG.check_required_env_vars()
 
     logger.info("Running process")
+    ItemSubmissionDB.set_table_name(CONFIG.item_table_name)
 
     ctx.obj["workflow"] = workflow
     ctx.obj["run_date"] = datetime.datetime.now(datetime.UTC)

--- a/dsc/cli.py
+++ b/dsc/cli.py
@@ -40,7 +40,6 @@ def main(
     ctx.obj["start_time"] = perf_counter()
     workflow_class = Workflow.get_workflow(workflow_name)
     workflow = workflow_class(batch_id=batch_id)
-    ctx.obj["workflow"] = workflow
 
     root_logger = logging.getLogger()
     logger.info(CONFIG.configure_logger(root_logger, verbose=verbose))
@@ -48,6 +47,9 @@ def main(
     CONFIG.check_required_env_vars()
 
     logger.info("Running process")
+
+    ctx.obj["workflow"] = workflow
+    ctx.obj["run_date"] = datetime.datetime.now(datetime.UTC)
 
 
 @main.result_callback()
@@ -79,7 +81,7 @@ def reconcile(ctx: click.Context, email_recipients: str | None = None) -> None:
     """Reconcile bitstreams with item identifiers from the metadata."""
     workflow = ctx.obj["workflow"]
 
-    reconciled = workflow.reconcile_bitstreams_and_metadata()
+    reconciled = workflow.reconcile_items(run_date=ctx.obj["run_date"])
 
     if email_recipients:
         workflow.send_report(

--- a/dsc/db/exceptions.py
+++ b/dsc/db/exceptions.py
@@ -1,2 +1,6 @@
 class ItemSubmissionExistsError(Exception):
     pass
+
+
+class ItemSubmissionCreateError(Exception):
+    pass

--- a/dsc/db/models.py
+++ b/dsc/db/models.py
@@ -113,7 +113,7 @@ class ItemSubmissionDB(Model):
         batch_id: str,
         workflow_name: str,
         **attributes: Unpack[OptionalItemAttributes],
-    ) -> None:
+    ) -> "ItemSubmissionDB":
         """Create a new item (row) in the 'dsc-item-submissions' table.
 
         This method also calls self.save() to write the item to DynamoDB.
@@ -140,6 +140,7 @@ class ItemSubmissionDB(Model):
             if exception.cause_response_code == "ConditionalCheckFailedException":
                 raise ItemSubmissionExistsError(
                     f"Item with item_identifier={item_identifier} (hash key) and "
-                    f"batch_id={batch_id} (range_key) already exists"
+                    f"batch_id={batch_id} (range key) already exists"
                 ) from exception
             raise
+        return item

--- a/dsc/workflows/base/__init__.py
+++ b/dsc/workflows/base/__init__.py
@@ -152,7 +152,8 @@ class Workflow(ABC):
                 self.write_reconcile_results_to_dynamodb(
                     item_identifier, status, run_date
                 )
-            except Exception:  # noqa: BLE001, S112
+            except Exception as exception:  # noqa: BLE001
+                logger.error(exception)  # noqa: TRY400
                 continue
         return reconciled
 

--- a/dsc/workflows/base/__init__.py
+++ b/dsc/workflows/base/__init__.py
@@ -125,8 +125,9 @@ class Workflow(ABC):
         from the metadata*. Results are written to DynamoDB.
 
         *This may not be the full set of item submissions in a batch
-        as there may item submissions represented by bitstreams but
-        are NOT included in the metadata.
+        as there may be bitstreams (intended for item submissions)
+        for which an item identifier cannot be retrieved.
+
         """
         reconciled = self.reconcile_bitstreams_and_metadata()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -189,7 +189,7 @@ def item_submission_instance(dspace_metadata):
 
 
 @pytest.fixture
-def mocked_item_db():
+def mocked_item_submission_db():
     with mock_aws():
         if not ItemSubmissionDB.exists():
             ItemSubmissionDB.create_table()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,6 +227,7 @@ def mocked_s3_simple_csv(mocked_s3, item_metadata):
         Key="simple_csv/batch-aaa/metadata.csv",
         Body=csv_buffer.getvalue(),
     )
+    return mocked_s3
 
 
 @pytest.fixture

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -4,7 +4,7 @@ from dsc.db.exceptions import ItemSubmissionExistsError
 from dsc.db.models import ItemSubmissionDB
 
 
-def test_db_itemsubmission_create_success(mocked_item_db):
+def test_db_itemsubmission_create_success(mocked_item_submission_db):
     ItemSubmissionDB.create(
         batch_id="batch-aaa", item_identifier="123", workflow_name="workflow"
     )
@@ -17,7 +17,7 @@ def test_db_itemsubmission_create_success(mocked_item_db):
     assert fetched_item.workflow_name == "workflow"
 
 
-def test_db_itemsubmission_create_if_exists_raise_error(mocked_item_db):
+def test_db_itemsubmission_create_if_exists_raise_error(mocked_item_submission_db):
     ItemSubmissionDB.create(
         batch_id="batch-aaa", item_identifier="123", workflow_name="workflow"
     )

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,6 +1,9 @@
-import pytest
+from unittest.mock import patch
 
-from dsc.db.exceptions import ItemSubmissionExistsError
+import pytest
+from pynamodb.exceptions import PutError
+
+from dsc.db.exceptions import ItemSubmissionCreateError, ItemSubmissionExistsError
 from dsc.db.models import ItemSubmissionDB
 
 
@@ -26,3 +29,35 @@ def test_db_itemsubmission_create_if_exists_raise_error(mocked_item_submission_d
         ItemSubmissionDB.create(
             batch_id="batch-aaa", item_identifier="123", workflow_name="workflow"
         )
+
+
+@patch("dsc.db.models.ItemSubmissionDB.save")
+def test_db_itemsubmission_create_if_puterror_raise_error(
+    mock_item_submission_db_save, mocked_item_submission_db
+):
+
+    class MockDynamoDBError(Exception):
+        cause_response_message = "This is a mocked DynamoDB Exception"
+
+    mock_item_submission_db_save.side_effect = PutError(cause=MockDynamoDBError)
+
+    with pytest.raises(ItemSubmissionCreateError):
+        ItemSubmissionDB.create(
+            batch_id="batch-aaa", item_identifier="123", workflow_name="workflow"
+        )
+
+
+def test_db_itemsubmission_get_or_create_success(mocked_item_submission_db):
+    ItemSubmissionDB.create(
+        batch_id="batch-aaa", item_identifier="123", workflow_name="workflow"
+    )
+
+    # retrieve created 'item' from ItemDB
+    fetched_item = ItemSubmissionDB.get_or_create(
+        batch_id="batch-aaa", item_identifier="123", workflow_name="workflow"
+    )
+
+    assert fetched_item
+    assert fetched_item.item_identifier == "123"
+    assert fetched_item.batch_id == "batch-aaa"
+    assert fetched_item.workflow_name == "workflow"

--- a/tests/test_workflow_simple_csv.py
+++ b/tests/test_workflow_simple_csv.py
@@ -43,6 +43,7 @@ def test_workflow_simple_csv_reconcile_items_if_item_submission_exists_success(
     mocked_item_submission_db,
     mocked_s3_simple_csv,
 ):
+    caplog.set_level("DEBUG")
     mock_s3_client_files_iter.return_value = [
         "s3://dsc/simple_csv/batch-aaa/123_001.pdf",
         "s3://dsc/simple_csv/batch-aaa/123_002.pdf",
@@ -55,6 +56,7 @@ def test_workflow_simple_csv_reconcile_items_if_item_submission_exists_success(
         workflow_name=simple_csv_workflow_instance.workflow_name,
         status=ItemSubmissionStatus.RECONCILE_SUCCESS,
     )
+
     reconciled = simple_csv_workflow_instance.reconcile_items(run_date=datetime.now(UTC))
 
     assert reconciled

--- a/tests/test_workflow_simple_csv.py
+++ b/tests/test_workflow_simple_csv.py
@@ -1,6 +1,8 @@
 # ruff: noqa: SLF001
+import csv
 import json
 from datetime import UTC, datetime
+from io import StringIO
 from unittest.mock import patch
 
 import pytest
@@ -57,14 +59,14 @@ def test_workflow_simple_csv_reconcile_items_if_item_submission_exists_success(
 
     assert reconciled
     assert (
-        "Record with primary keys item_identifier=123 (hash key) and "
-        "batch_id=batch-aaa (range key) was previously reconciled, skipping update"
+        "Record with primary keys batch_id=batch-aaa (hash key) and "
+        "item_identifier=123 (range key) was previously reconciled, skipping update"
     ) in caplog.text
 
 
 @freeze_time("2025-01-01 09:00:00")
 @patch("dsc.utilities.aws.s3.S3Client.files_iter")
-def test_workflow_simple_csv_reconcile_items_if_no_metadata_success(
+def test_workflow_simple_csv_reconcile_items_if_no_metadata_exclude_from_db(
     mock_s3_client_files_iter,
     caplog,
     simple_csv_workflow_instance,
@@ -82,9 +84,65 @@ def test_workflow_simple_csv_reconcile_items_if_no_metadata_success(
     assert not reconciled
 
     # since item identifiers are retrieved from SimpleCSV.item_metadata_iter
-    # bitstreams without metadata are NOT written to the dsc-item-submissions table
+    # item identifiers associated with bitstreams without metadata are
+    # NOT written to the DynamoDB table
     with pytest.raises(DoesNotExist):
         ItemSubmissionDB.get(hash_key="batch-aaa", range_key="456")
+
+
+@freeze_time("2025-01-01 09:00:00")
+@patch("dsc.utilities.aws.s3.S3Client.files_iter")
+def test_workflow_simple_csv_reconcile_items_if_no_bitstreams_include_in_db(
+    mock_s3_client_files_iter,
+    caplog,
+    simple_csv_workflow_instance,
+    mocked_item_submission_db,
+    mocked_s3_simple_csv,
+):
+    mock_s3_client_files_iter.return_value = [
+        "s3://dsc/simple_csv/batch-aaa/123_001.pdf",
+        "s3://dsc/simple_csv/batch-aaa/123_002.pdf",
+    ]
+
+    # update metadata CSV file
+    csv_buffer = StringIO()
+    writer = csv.DictWriter(
+        csv_buffer, fieldnames=["title", "contributor", "item_identifier"]
+    )
+    writer.writeheader()
+    writer.writerows(
+        [
+            {
+                "title": "Title",
+                "contributor": "Author 1|Author 2",
+                "item_identifier": "123",
+            },
+            {
+                "title": "Title",
+                "contributor": "Author 1|Author 2",
+                "item_identifier": "456",
+            },
+        ]
+    )
+
+    # seek to the beginning of the in-memory file before uploading
+    csv_buffer.seek(0)
+
+    mocked_s3_simple_csv.put_object(
+        Bucket="dsc",
+        Key="simple_csv/batch-aaa/metadata.csv",
+        Body=csv_buffer.getvalue(),
+    )
+
+    # create record to force raise dsc.db.exceptions ItemSubmissionExistsError
+    reconciled = simple_csv_workflow_instance.reconcile_items(run_date=datetime.now(UTC))
+    assert not reconciled
+
+    # since item identifiers are retrieved from SimpleCSV.item_metadata_iter
+    # item identifiers associated with metadata without bitstreams
+    # ARE written to the DynamoDB table
+    record = ItemSubmissionDB.get(hash_key="batch-aaa", range_key="456")
+    assert record
 
 
 @patch("dsc.utilities.aws.s3.S3Client.files_iter")


### PR DESCRIPTION
### Purpose and background context

This work is an important part of ensuring that running DSC is idempotent via tracking the state of item submissions
using a DynamoDB table. 

It is during the `reconcile` step that an item submission is first written to the `dsc-item-submissions` table. At the end of the `reconcile` command, the table is updated with the results. Here are some key points that I'd appreciate additional reflection on:

**NOTE:** I've enumerated each point below so ya'll can refer to it in your PR review summaries/comments as needed! 🤓 

1.  As stated in [the docstring of the  new final method `Workflow.reconcile_items`](https://github.com/MITLibraries/dspace-submission-composer/pull/180/commits/932ded30b212b59c3774075745684c70e761630c#diff-9409cf7165577c3250e707080466409d47908aae682829ddb8a1abadecda795aR122-R132), what gets recorded in the DynamoDB table may not be the intended "full" set of item submissions.
   * **What does this mean:** For the `SimpleCSV` workflow, potential item submissions (represented by bitstreams) that are _missing metadata_ (not included the metadata CSV file) will **not** get recorded in DynamoDB.
   * **Why:** A workflow's ability to capture the intended "full" set of item identifiers depends on the Workflow's `item_metadata_iter()` method.
      * For `SimpleCSV`, [the workflow pulls item identifiers from the metadata CSV file](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1316-update-reconcile-command-to-use-dynamodb/dsc/workflows/base/simple_csv.py#L137-L157).
      * For `OpenCourseWare`, the[ workflow pulls item identifiers from the filenames in the batch folder on S3](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1316-update-reconcile-command-to-use-dynamodb/dsc/workflows/opencourseware.py#L94-L107), so **this isn't an issue.**
2. [`Workflow.reconcile_items` uses the `workflow_events` instance attribute](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1316-update-reconcile-command-to-use-dynamodb/dsc/workflows/base/__init__.py#L141)
   * Prior to this change, `WorkflowEvents` had only been used to communicate the results of a DSC `Workflow` run to the DSC reporting modules.
3. These [lines of code](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1316-update-reconcile-command-to-use-dynamodb/dsc/workflows/base/__init__.py#L221-L243) outline when the results of a reconcile for an item submission are **skipped or updated**.
4. The new final method `reconcile_items` _requires_ `reconcile_bitstreams_and_metadata` to be implemented, but we've previously noted that the latter may not be needed for every workflow. 🤔 
   * My vote is to not let that be a reason to refrain from merging these changes (pending required updates, that is) and revisit this point.
5. Lastly, **_naming conventions_** 🙃: 
   * CLI command: `reconcile`
   * Workflow entrypoint/command: `reconcile_items` (taken from `submit_items`)
   * Workflow internal methods / submethods: `reconcile_bitstreams_and_metadata`, `write_reconcile_results_to_dynamodb`


### How can a reviewer manually see the effects of these changes?
For now, [these unit tests using the "test" `SimpleCSV` workflow instance](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1316-update-reconcile-command-to-use-dynamodb/tests/test_workflow_simple_csv.py#L13-L87) are sufficient.


Will update this section / send a message in Slack if I am able to quickly pull an example in Dev!

### Includes new or updated dependencies?
YES - Adds `pynamodb` to **packages**

### Changes expectations for external applications?
Any deposits involving DSC will be recorded in the DynamoDB table.

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1316

### Developer
- [x] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

