### PR TITLE
Fix args when retrieving record from DynamoDB during 'finalize'

### DIFF
--- a/dsc/workflows/base/__init__.py
+++ b/dsc/workflows/base/__init__.py
@@ -657,9 +657,19 @@ class Workflow(ABC):
             item_identifier = message_attributes["PackageID"]["StringValue"]
 
             # get record from ItemSubmissionDB
-            item_submission_record = ItemSubmissionDB.get(
-                hash_key=item_identifier, range_key=self.batch_id
-            )
+            try:
+                item_submission_record = ItemSubmissionDB.get(
+                    hash_key=self.batch_id, range_key=item_identifier
+                )
+            except DoesNotExist:
+                logger.warning(
+                    "Record "
+                    f"{ITEM_SUBMISSION_LOG_STR.format(batch_id=self.batch_id,
+                                      item_identifier=item_identifier)}"
+                    "not found. Verify that it been reconciled."
+                )
+                continue
+
             current_status = item_submission_record.status
 
             logger.info(


### PR DESCRIPTION
### Purpose and background context
Testing in Dev revealed there was a mixup in the args provided to the ItemSubmissionDB.get method during the 'finalize' step.

### How can a reviewer manually see the effects of these changes?
Testing details will be written up in https://mitlibraries.atlassian.net/browse/IN-1179.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1344

### Developer
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [ ] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

