### PR TITLE
Align workflow methods for iterating over item metadata

### DIFF
--- a/dsc/workflows/metadata_mapping/opencourseware.json
+++ b/dsc/workflows/metadata_mapping/opencourseware.json
@@ -1,23 +1,46 @@
 {
     "dc.title": {
-        "source_field_name": "course_title",
-        "language": "en_US",
+        "source_field_name": "dc.title",
+        "required": true
+    },
+    "dc.date.issued": {
+        "source_field_name": "dc.date.issued",
         "required": true
     },
     "dc.description.abstract": {
-        "source_field_name": "course_description"
-    },
-    "dc.subject": {
-        "source_field_name": "topics"
-    },
-    "dc.date.issued": {
-        "source_field_name": "year"
-    },
-    "dc.identifier.other": {
-        "source_field_name": "primary_course_number"
+        "source_field_name": "dc.description.abstract"
     },
     "dc.contributor.author": {
-        "source_field_name": "instructors",
-        "delimiter": "|"
+        "source_field_name": "dc.contributor.author"
+    },
+    "dc_contributor_department": {
+        "source_field_name": "dc.contributor.department"
+    },
+    "creativework.learningresourcetype": {
+        "source_field_name": "creativework.learningresourcetype"
+    },
+    "dc.subject": {
+        "source_field_name": "dc.subject"
+    },
+    "dc.identifier.other": {
+        "source_field_name": "dc.identifier.other"
+    },
+    "dc.coverage.temporal": {
+        "source_field_name": "dc.coverage.temporal"
+    },
+    "dc.audience.educationlevel": {
+        "source_field_name": "dc.audience.educationlevel"
+    },
+    "dc.type": {
+        "source_field_name": "dc.type"
+    },
+    "dc.rights": {
+        "source_field_name": "dc.rights"
+    },
+    "dc.rights.uri": {
+        "source_field_name": "dc.rights.uri"
+    },
+    "dc.language.iso": {
+        "source_field_name": "dc.language.iso"
     }
 }

--- a/dsc/workflows/opencourseware.py
+++ b/dsc/workflows/opencourseware.py
@@ -397,11 +397,11 @@ class OpenCourseWare(Workflow):
         ):
             try:
                 source_metadata = self._read_metadata_from_zip_file(file)
-                transformed_metadata = self.metadata_transformer.transform(
-                    source_metadata
-                )
+
             except FileNotFoundError:
-                transformed_metadata = {}
+                source_metadata = {}
+
+            transformed_metadata = self.metadata_transformer.transform(source_metadata)
 
             yield {
                 "item_identifier": self._parse_item_identifier(file),

--- a/tests/test_workflow_opencourseware.py
+++ b/tests/test_workflow_opencourseware.py
@@ -4,6 +4,102 @@ from unittest.mock import patch
 
 import pytest
 
+from dsc.item_submission import ItemSubmission
+
+
+@patch("dsc.workflows.opencourseware.OpenCourseWare._read_metadata_from_zip_file")
+@patch("dsc.utilities.aws.s3.S3Client.files_iter")
+def test_workflow_ocw_metadata_mapping_dspace_metadata_success(
+    mock_s3_client_files_iter,
+    mock_opencourseware_read_metadata_from_zip_file,
+    caplog,
+    opencourseware_source_metadata,
+    opencourseware_workflow_instance,
+):
+    mock_s3_client_files_iter.return_value = [
+        "s3://dsc/opencourseware/batch-aaa/123.zip",
+    ]
+    mock_opencourseware_read_metadata_from_zip_file.return_value = (
+        opencourseware_source_metadata
+    )
+
+    item_submission = ItemSubmission(
+        batch_id="aaa", item_identifier="123", workflow_name="opencourseware"
+    )
+    item_submission.create_dspace_metadata(
+        item_metadata=next(opencourseware_workflow_instance.item_metadata_iter()),
+        metadata_mapping=opencourseware_workflow_instance.metadata_mapping,
+    )
+
+    assert item_submission.dspace_metadata["metadata"] == [
+        {
+            "key": "dc.title",
+            "value": "14.02 Principles of Macroeconomics, Fall 2004",
+            "language": None,
+        },
+        {"key": "dc.date.issued", "value": "2004", "language": None},
+        {
+            "key": "dc.description.abstract",
+            "value": (
+                "This course provides an overview of the following macroeconomic "
+                "issues: the determination of output, employment, unemployment, "
+                "interest rates, and inflation. Monetary and fiscal policies are "
+                "discussed, as are public debt and international economic issues. "
+                "This course also introduces basic models of macroeconomics and "
+                "illustrates principles with the experience of the United States "
+                "and other economies.\n"
+            ),
+            "language": None,
+        },
+        {"key": "dc.contributor.author", "value": "Caballero, Ricardo", "language": None},
+        {
+            "key": "dc_contributor_department",
+            "value": "Massachusetts Institute of Technology. Department of Economics",
+            "language": None,
+        },
+        {
+            "key": "creativework.learningresourcetype",
+            "value": "Problem Sets with Solutions",
+            "language": None,
+        },
+        {
+            "key": "creativework.learningresourcetype",
+            "value": "Exams with Solutions",
+            "language": None,
+        },
+        {
+            "key": "creativework.learningresourcetype",
+            "value": "Lecture Notes",
+            "language": None,
+        },
+        {
+            "key": "dc.subject",
+            "value": "Social Science - Economics - International Economics",
+            "language": None,
+        },
+        {
+            "key": "dc.subject",
+            "value": "Social Science - Economics - Macroeconomics",
+            "language": None,
+        },
+        {"key": "dc.identifier.other", "value": "14.02", "language": None},
+        {"key": "dc.identifier.other", "value": "14.02-Fall2004", "language": None},
+        {"key": "dc.coverage.temporal", "value": "Fall 2004", "language": None},
+        {"key": "dc.audience.educationlevel", "value": "Undergraduate", "language": None},
+        {"key": "dc.type", "value": "Learning Object", "language": None},
+        {
+            "key": "dc.rights",
+            "value": "Attribution-NonCommercial-NoDerivs 4.0 United States",
+            "language": None,
+        },
+        {
+            "key": "dc.rights.uri",
+            "value": "https://creativecommons.org/licenses/by-nc-nd/4.0/deed.en",
+            "language": None,
+        },
+        {"key": "dc.language.iso", "value": "en_US", "language": None},
+    ]
+
 
 @patch("dsc.workflows.opencourseware.OpenCourseWare._read_metadata_from_zip_file")
 @patch("dsc.utilities.aws.s3.S3Client.files_iter")


### PR DESCRIPTION
### Purpose and background context

This PR is part of a series of updates related to aligning the structure of the `reconcile` method with the other DSC CLI commands (`submit` and `finalize`). Specifically, this PR aligns the method signatures of the `item_metadata_iter` methods. For the OpenCourseWare (OCW) workflow, the method would previously raise a `FileNotFoundError` if a metadata JSON file (`data.json`) was not found in the zip file. These changes ensure that OCW returns a dict regardless (containing at least the item identifier). 

This **also fixes a breaking change** that was introduced by the previous update that introduced a metadata transformer for OCW (https://github.com/MITLibraries/dspace-submission-composer/pull/192). During that implementation, I missed that the metadata mapping JSON file was still required as all workflows create DSpace metadata (i.e., "transformed source metadata") through the shared `ItemSubmission.create_dspace_metadata` method. I opted to update the metadata mapping JSON file for now to narrow the scope of this PR.

**NOTE:** In my discussions with @ghukill, we originally thought we could take a step further with `OpenCourseWare.item_metadata_iter` and ensure the method returns the "source metadata" (pre-transformation), however, due to the same reason above, this would require changing how/when we create DSpace metadata. I strongly suggest tabling this discussion for later and focusing on **aligning the structure of the `reconcile` command** for now.

### How can a reviewer manually see the effects of these changes?
Review added unit test.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
* https://mitlibraries.atlassian.net/browse/IN-1431