### PR TITLE
Cache list of bitstream URIs to Workflow class

### DIFF
--- a/dsc/workflows/base/__init__.py
+++ b/dsc/workflows/base/__init__.py
@@ -136,6 +136,9 @@ class Workflow(ABC):
             "errors": 0,
         }
 
+        # cache list of bitstreams
+        self._batch_bitstream_uris: list[str] | None = None
+
     @property
     @abstractmethod
     def metadata_mapping_path(self) -> str:
@@ -161,6 +164,12 @@ class Workflow(ABC):
         return f"{self.workflow_name}/{self.batch_id}/"
 
     @property
+    def batch_bitstream_uris(self) -> list[str]:
+        if not self._batch_bitstream_uris:
+            self._batch_bitstream_uris = self.get_batch_bitstream_uris()
+        return self._batch_bitstream_uris
+
+    @property
     def retry_threshold(self) -> int:
         return CONFIG.retry_threshold
 
@@ -183,6 +192,10 @@ class Workflow(ABC):
         for subclass in cls.__subclasses__():
             yield from subclass._get_subclasses()  # noqa: SLF001
             yield subclass
+
+    @abstractmethod
+    def get_batch_bitstream_uris(self) -> list[str]:
+        """Get list of bitstream URIs for a batch."""
 
     @abstractmethod
     def item_metadata_iter(self) -> Iterator[dict[str, Any]]:

--- a/dsc/workflows/base/__init__.py
+++ b/dsc/workflows/base/__init__.py
@@ -197,6 +197,11 @@ class Workflow(ABC):
     def get_batch_bitstream_uris(self) -> list[str]:
         """Get list of bitstream URIs for a batch."""
 
+    @final
+    def get_item_bitstream_uris(self, item_identifier: str) -> list[str]:
+        """Get list of bitstreams URIs for an item."""
+        return [uri for uri in self.batch_bitstream_uris if item_identifier in uri]
+
     @abstractmethod
     def item_metadata_iter(self) -> Iterator[dict[str, Any]]:
         """Iterate through batch metadata to yield item metadata.
@@ -325,7 +330,7 @@ class Workflow(ABC):
                     s3_bucket=self.s3_bucket,
                     batch_path=self.batch_path,
                 )
-                item_submission.bitstream_s3_uris = self.get_bitstream_s3_uris(
+                item_submission.bitstream_s3_uris = self.get_item_bitstream_uris(
                     item_identifier
                 )
 
@@ -366,16 +371,6 @@ class Workflow(ABC):
             f"for batch '{self.batch_id}': {json.dumps(self.submission_summary)}"
         )
         return items
-
-    @abstractmethod
-    def get_bitstream_s3_uris(self, item_identifier: str) -> list[str]:
-        """Get bitstreams for an item submission according to the workflow subclass.
-
-        MUST be overridden by workflow subclasses.
-
-        Args:
-            item_identifier: The identifier used for locating the item's bitstreams.
-        """
 
     @final
     def finalize_items(self) -> None:

--- a/dsc/workflows/base/simple_csv.py
+++ b/dsc/workflows/base/simple_csv.py
@@ -183,23 +183,3 @@ class SimpleCSV(Workflow):
 
             for _, row in metadata_df.iterrows():
                 yield row.to_dict()
-
-    def get_bitstream_s3_uris(self, item_identifier: str) -> list[str]:
-        """Get S3 URIs for bitstreams for a given item.
-
-        This method uses S3Client.files_iter to get a list of files
-        on S3 stored at s3://bucket/prefix/ and includes the 'item_identifier'
-        in the object key.
-
-        - If the exact filename is provided as 'item_identifier', only
-          one bitstream is retrieved.
-        - If a prefix is provided as 'item_identifier', one or more
-          bitstreams are retrieved.
-
-        Args:
-            item_identifier: Item identifier used to filter bitstreams.
-
-        Returns:
-            Bitstream URIs for a given item.
-        """
-        return [uri for uri in self.batch_bitstreams if item_identifier in uri]

--- a/dsc/workflows/base/simple_csv.py
+++ b/dsc/workflows/base/simple_csv.py
@@ -31,6 +31,15 @@ class SimpleCSV(Workflow):
     def item_identifier_column_names(self) -> list[str]:
         return ["item_identifier"]
 
+    def get_batch_bitstream_uris(self) -> list[str]:
+        return list(
+            S3Client().files_iter(
+                bucket=self.s3_bucket,
+                prefix=self.batch_path,
+                exclude_prefixes=self.exclude_prefixes,
+            )
+        )
+
     def reconcile_bitstreams_and_metadata(
         self, metadata_file: str = "metadata.csv"
     ) -> bool:
@@ -54,23 +63,14 @@ class SimpleCSV(Workflow):
             metadata_file
         )
 
-        # get bitstreams
-        s3_client = S3Client()
-        bitstream_filenames = list(
-            s3_client.files_iter(
-                bucket=self.s3_bucket,
-                prefix=self.batch_path,
-                exclude_prefixes=["archived", metadata_file, "metadata.json"],
-            )
-        )
-
         reconciled_items = self._match_metadata_to_bitstreams(
-            metadata_item_identifiers, bitstream_filenames
+            metadata_item_identifiers, self.batch_bitstream_uris
         )
         self.workflow_events.reconciled_items = reconciled_items
 
         bitstreams_without_metadata = list(
-            set(bitstream_filenames) - set(itertools.chain(*reconciled_items.values()))
+            set(self.batch_bitstream_uris)
+            - set(itertools.chain(*reconciled_items.values()))
         )
         metadata_without_bitstreams = list(
             metadata_item_identifiers - set(reconciled_items.keys())
@@ -202,12 +202,4 @@ class SimpleCSV(Workflow):
         Returns:
             Bitstream URIs for a given item.
         """
-        s3_client = S3Client()
-        return list(
-            s3_client.files_iter(
-                bucket=self.s3_bucket,
-                prefix=self.batch_path,
-                item_identifier=item_identifier,
-                exclude_prefixes=self.exclude_prefixes,
-            )
-        )
+        return [uri for uri in self.batch_bitstreams if item_identifier in uri]

--- a/dsc/workflows/opencourseware.py
+++ b/dsc/workflows/opencourseware.py
@@ -316,6 +316,18 @@ class OpenCourseWare(Workflow):
     def metadata_mapping_path(self) -> str:
         return "dsc/workflows/metadata_mapping/opencourseware.json"
 
+    def get_batch_bitstream_uris(self) -> list[str]:
+        """Get list of URIs for all zipfiles within the batch folder."""
+        s3_client = S3Client()
+        return list(
+            s3_client.files_iter(
+                bucket=self.s3_bucket,
+                prefix=self.batch_path,
+                file_type=".zip",
+                exclude_prefixes=self.exclude_prefixes,
+            )
+        )
+
     def reconcile_bitstreams_and_metadata(self) -> bool:
         """Reconcile bitstreams against item metadata.
 
@@ -337,11 +349,8 @@ class OpenCourseWare(Workflow):
 
         reconciled_items = {}
         bitstreams_without_metadata = []
-        s3_client = S3Client()
 
-        for file in s3_client.files_iter(
-            bucket=self.s3_bucket, prefix=self.batch_path, file_type=".zip"
-        ):
+        for file in self.batch_bitstream_uris:
             item_identifier = self._parse_item_identifier(file)
 
             try:
@@ -391,10 +400,7 @@ class OpenCourseWare(Workflow):
         NOTE: Item identifiers are retrieved from the filenames of the zip
         files, which follow the naming format "<item_identifier>.zip".
         """
-        s3_client = S3Client()
-        for file in s3_client.files_iter(
-            bucket=self.s3_bucket, prefix=self.batch_path, file_type=".zip"
-        ):
+        for file in self.batch_bitstream_uris:
             try:
                 source_metadata = self._read_metadata_from_zip_file(file)
 
@@ -430,13 +436,4 @@ class OpenCourseWare(Workflow):
         return file.split("/")[-1].removesuffix(".zip")
 
     def get_bitstream_s3_uris(self, item_identifier: str) -> list[str]:
-        s3_client = S3Client()
-        return list(
-            s3_client.files_iter(
-                bucket=self.s3_bucket,
-                prefix=self.batch_path,
-                item_identifier=item_identifier,
-                file_type=".zip",
-                exclude_prefixes=self.exclude_prefixes,
-            )
-        )
+        return [uri for uri in self.batch_bitstreams if item_identifier in uri]

--- a/dsc/workflows/opencourseware.py
+++ b/dsc/workflows/opencourseware.py
@@ -434,6 +434,3 @@ class OpenCourseWare(Workflow):
     def _parse_item_identifier(self, file: str) -> str:
         """Parse item identifier from bitstream zip file."""
         return file.split("/")[-1].removesuffix(".zip")
-
-    def get_bitstream_s3_uris(self, item_identifier: str) -> list[str]:
-        return [uri for uri in self.batch_bitstreams if item_identifier in uri]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,13 @@ class TestWorkflow(Workflow):
     def output_queue(self) -> str:
         return "mock-output-queue"
 
+    def get_batch_bitstream_uris(self) -> list[str]:
+        return [
+            "s3://dsc/test/batch-aaa/123_01.pdf",
+            "s3://dsc/test/batch-aaa/123_02.pdf",
+            "s3://dsc/test/batch-aaa/789_01.pdf",
+        ]
+
     def reconcile_bitstreams_and_metadata(self):
         raise TypeError(
             f"Method '{self.reconcile_bitstreams_and_metadata.__name__}' "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,14 +63,6 @@ class TestWorkflow(Workflow):
             },
         ]
 
-    def get_bitstream_s3_uris(self, item_identifier):
-        bitstreams = [
-            "s3://dsc/test/batch-aaa/123_01.pdf",
-            "s3://dsc/test/batch-aaa/123_02.pdf",
-            "s3://dsc/test/batch-aaa/789_01.pdf",
-        ]
-        return [bitstream for bitstream in bitstreams if item_identifier in bitstream]
-
 
 class TestSimpleCSV(SimpleCSV):
 

--- a/tests/test_workflow_opencourseware.py
+++ b/tests/test_workflow_opencourseware.py
@@ -250,7 +250,7 @@ def test_workflow_ocw_read_metadata_from_zip_file_without_metadata_raise_error(
 
 
 @patch("dsc.utilities.aws.s3.S3Client.files_iter")
-def test_workflow_ocw_get_bitstreams_uris_success(
+def test_workflow_ocw_get_item_bitstream_uris_success(
     mock_s3_client_files_iter, opencourseware_workflow_instance
 ):
     mock_s3_client_files_iter.return_value = [
@@ -258,6 +258,6 @@ def test_workflow_ocw_get_bitstreams_uris_success(
         "s3://dsc/opencourseware/batch-aaa/124.zip",
     ]
 
-    assert opencourseware_workflow_instance.get_bitstream_s3_uris(
+    assert opencourseware_workflow_instance.get_item_bitstream_uris(
         item_identifier="123.zip"
     )

--- a/tests/test_workflow_opencourseware.py
+++ b/tests/test_workflow_opencourseware.py
@@ -259,5 +259,5 @@ def test_workflow_ocw_get_bitstreams_uris_success(
     ]
 
     assert opencourseware_workflow_instance.get_bitstream_s3_uris(
-        item_identifier="123.pdf"
+        item_identifier="123.zip"
     )

--- a/tests/test_workflow_simple_csv.py
+++ b/tests/test_workflow_simple_csv.py
@@ -244,7 +244,7 @@ def test_workflow_simple_csv_item_metadata_iter_processing_success(
 
 
 @patch("dsc.utilities.aws.s3.S3Client.files_iter")
-def test_workflow_simple_csv_get_bitstreams_uris_if_prefix_id_success(
+def test_workflow_simple_csv_get_item_bitstream_uris_if_prefix_id_success(
     mock_s3_client_files_iter, simple_csv_workflow_instance
 ):
     mock_s3_client_files_iter.return_value = [
@@ -252,20 +252,22 @@ def test_workflow_simple_csv_get_bitstreams_uris_if_prefix_id_success(
         "s3://dsc/simple_csv/batch-aaa/123_002.pdf",
     ]
 
-    assert simple_csv_workflow_instance.get_bitstream_s3_uris(item_identifier="123") == [
+    assert simple_csv_workflow_instance.get_item_bitstream_uris(
+        item_identifier="123"
+    ) == [
         "s3://dsc/simple_csv/batch-aaa/123_001.pdf",
         "s3://dsc/simple_csv/batch-aaa/123_002.pdf",
     ]
 
 
 @patch("dsc.utilities.aws.s3.S3Client.files_iter")
-def test_workflow_simple_csv_get_bitstreams_uris_if_filename_id_success(
+def test_workflow_simple_csv_get_item_bitstream_uris_if_filename_id_success(
     mock_s3_client_files_iter, simple_csv_workflow_instance
 ):
     mock_s3_client_files_iter.return_value = [
         "s3://dsc/simple_csv/batch-aaa/123.pdf",
     ]
 
-    assert simple_csv_workflow_instance.get_bitstream_s3_uris(
+    assert simple_csv_workflow_instance.get_item_bitstream_uris(
         item_identifier="123.pdf"
     ) == ["s3://dsc/simple_csv/batch-aaa/123.pdf"]


### PR DESCRIPTION
### Purpose and background context
This PR is part of a series of updates related to aligning the structure of the `reconcile_items` method with the other workflow methods (`submit_items` and `finalize_items`). This PR ensures that a list of bitstreams for a given batch is cached to the Workflow the first time it is referenced in the code and updates all dependent methods to use the cache.

### How can a reviewer manually see the effects of these changes?
Review updated unit tests.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1432