### PR TITLE
Add ArchivesSpace workflow

### DIFF
--- a/dsc/db/models.py
+++ b/dsc/db/models.py
@@ -32,6 +32,7 @@ class ItemSubmissionStatus(StrEnum):
 
 
 class OptionalItemAttributes(TypedDict, total=False):
+    source_system_identifier: str
     collection_handle: str
     dspace_handle: str
     status: str
@@ -57,6 +58,8 @@ class ItemSubmissionDB(Model):
         item_identifier [sort key]: A unique identifier for an item submission
             in a batch.
         workflow_name: The name of the DSC workflow.
+        source_system_identifier: An identifier used to linked the ingested item to its
+        record in the source system.
         collection_handle: A persistent, globally unique identifier for a
             collection in DSpace. The handle is used in the DSS submission message.
         dspace_handle: A persistent, globally unique identifier for a digital object
@@ -89,6 +92,7 @@ class ItemSubmissionDB(Model):
     batch_id = UnicodeAttribute(hash_key=True)
     item_identifier = UnicodeAttribute(range_key=True)
     workflow_name = UnicodeAttribute()
+    source_system_identifier = UnicodeAttribute(null=True)
     collection_handle = UnicodeAttribute(null=True)
     last_run_date = UTCDateTimeAttribute(null=True)
     submit_attempts = NumberAttribute(default_for_new=0)

--- a/dsc/item_submission.py
+++ b/dsc/item_submission.py
@@ -49,6 +49,7 @@ class ItemSubmission:
     batch_id: str
     item_identifier: str
     workflow_name: str
+    source_system_identifier: str | None = None
     collection_handle: str | None = None
     last_run_date: datetime | None = None
     submit_attempts: int = 0
@@ -67,7 +68,11 @@ class ItemSubmission:
 
     @classmethod
     def get_or_create(
-        cls, batch_id: str, item_identifier: str, workflow_name: str
+        cls,
+        batch_id: str,
+        item_identifier: str,
+        workflow_name: str,
+        source_system_identifier: str | None = None,
     ) -> ItemSubmission:
         """Get or create an ItemSubmission.
 
@@ -75,7 +80,10 @@ class ItemSubmission:
         finds a corresponding record.
         """
         return cls.get(batch_id, item_identifier) or cls.create(
-            batch_id, item_identifier, workflow_name
+            batch_id=batch_id,
+            item_identifier=item_identifier,
+            workflow_name=workflow_name,
+            source_system_identifier=source_system_identifier,
         )
 
     @classmethod
@@ -107,10 +115,19 @@ class ItemSubmission:
 
     @classmethod
     def create(
-        cls, batch_id: str, item_identifier: str, workflow_name: str
+        cls,
+        batch_id: str,
+        item_identifier: str,
+        workflow_name: str,
+        source_system_identifier: str | None = None,
     ) -> ItemSubmission:
         """Create an ItemSubmission."""
-        return cls(batch_id, item_identifier, workflow_name)
+        return cls(
+            batch_id=batch_id,
+            item_identifier=item_identifier,
+            workflow_name=workflow_name,
+            source_system_identifier=source_system_identifier,
+        )
 
     @classmethod
     def _from_db(cls, item_submission_db: ItemSubmissionDB) -> ItemSubmission:

--- a/dsc/workflows/__init__.py
+++ b/dsc/workflows/__init__.py
@@ -3,9 +3,17 @@
 All primary functions used by CLI are importable from here.
 """
 
+from dsc.workflows.archivesspace import ArchivesSpace
 from dsc.workflows.base import Workflow, WorkflowEvents
 from dsc.workflows.base.simple_csv import SimpleCSV
 from dsc.workflows.opencourseware import OpenCourseWare
 from dsc.workflows.sccs import SCCS
 
-__all__ = ["SCCS", "OpenCourseWare", "SimpleCSV", "Workflow", "WorkflowEvents"]
+__all__ = [
+    "SCCS",
+    "ArchivesSpace",
+    "OpenCourseWare",
+    "SimpleCSV",
+    "Workflow",
+    "WorkflowEvents",
+]

--- a/dsc/workflows/archivesspace.py
+++ b/dsc/workflows/archivesspace.py
@@ -1,6 +1,6 @@
-import csv
 import logging
 
+import pandas as pd
 import smart_open
 
 from dsc.db.models import ItemSubmissionStatus
@@ -41,12 +41,13 @@ class ArchivesSpace(SimpleCSV):
         handle_uri_mapping = {}
 
         # find item submissions that were successfully ingested on the current run
-        for item_submission in [
+        successful_item_submissions: list[ItemSubmission] = [
             item_submission
             for item_submission in ItemSubmission.get_batch(self.batch_id)
             if item_submission.last_run_date == self.run_date
             and item_submission.status == ItemSubmissionStatus.INGEST_SUCCESS
-        ]:
+        ]
+        for item_submission in successful_item_submissions:
             handle_uri_mapping[item_submission.source_system_identifier] = (
                 item_submission.dspace_handle
                 if item_submission.dspace_handle
@@ -58,14 +59,26 @@ class ArchivesSpace(SimpleCSV):
             )
             return
 
+        # create dataframe
+        df = pd.DataFrame(
+            [
+                {
+                    "ao_uri": item.source_system_identifier,
+                    "dspace_handle": (
+                        item.dspace_handle
+                        if item.dspace_handle
+                        else "DSpace handle not set, possible error"
+                    ),
+                }
+                for item in successful_item_submissions
+            ]
+        )
+
         # create report in S3 bucket
         with smart_open.open(
             f"s3://{self.output_path}/{self.batch_id}-{run_date_str}.csv", "w"
         ) as csv_file:
-            writer = csv.writer(csv_file)
-            writer.writerow(["ao_uri", "dspace_handle"])
-            for ao_uri, dspace_handle in handle_uri_mapping.items():
-                writer.writerow([ao_uri, dspace_handle])
+            df.to_csv(csv_file, index=False)
 
         logger.debug(
             f"Completed ingest report for batch '{self.batch_id}' on run date"

--- a/dsc/workflows/archivesspace.py
+++ b/dsc/workflows/archivesspace.py
@@ -1,0 +1,73 @@
+import csv
+import logging
+
+import smart_open
+
+from dsc.db.models import ItemSubmissionStatus
+from dsc.item_submission import ItemSubmission
+from dsc.workflows.base.simple_csv import SimpleCSV
+
+logger = logging.getLogger(__name__)
+
+
+class ArchivesSpace(SimpleCSV):
+    """Workflow for ArchivesSpace deposits.
+
+    The deposits managed by this workflow are requested by the Department of Distinctive
+    Collections (DDC) and are submitted to Dome. This workflow utilizes the
+    workflow_specific_processing() method to produce a report for linking ArchivesSpace
+    records to the newly-ingested Dome items. The report is sent to an S3 bucket in the
+    output_path property after it is generated.
+    """
+
+    workflow_name: str = "archivesspace"
+
+    @property
+    def metadata_mapping_path(self) -> str:
+        return "dsc/workflows/metadata_mapping/archivesspace.json"
+
+    @property
+    def output_path(self) -> str:
+        return "output-bucket"
+
+    def workflow_specific_processing(self) -> None:
+        """Generate an ingest report linking DSpace handles to ArchivesSpace URIs.
+
+        This report is used in a separate process for updating metadata records in
+        ArchivesSpace with the newly-created DSpace handles.
+        """
+        run_date_str = self.run_date.strftime("%Y-%m-%d-%H:%M:%S")
+
+        handle_uri_mapping = {}
+
+        # find item submissions that were successfully ingested on the current run
+        for item_submission in [
+            item_submission
+            for item_submission in ItemSubmission.get_batch(self.batch_id)
+            if item_submission.last_run_date == self.run_date
+            and item_submission.status == ItemSubmissionStatus.INGEST_SUCCESS
+        ]:
+            handle_uri_mapping[item_submission.source_system_identifier] = (
+                item_submission.dspace_handle
+                if item_submission.dspace_handle
+                else "DSpace handle not set, possible error"
+            )
+        if not handle_uri_mapping:
+            logger.info(
+                f"No items ingested for '{self.batch_id}' on run date '{run_date_str}'"
+            )
+            return
+
+        # create report in S3 bucket
+        with smart_open.open(
+            f"s3://{self.output_path}/{self.batch_id}-{run_date_str}.csv", "w"
+        ) as csv_file:
+            writer = csv.writer(csv_file)
+            writer.writerow(["ao_uri", "dspace_handle"])
+            for ao_uri, dspace_handle in handle_uri_mapping.items():
+                writer.writerow([ao_uri, dspace_handle])
+
+        logger.debug(
+            f"Completed ingest report for batch '{self.batch_id}' on run date"
+            f" '{run_date_str}'"
+        )

--- a/dsc/workflows/base/__init__.py
+++ b/dsc/workflows/base/__init__.py
@@ -248,6 +248,7 @@ class Workflow(ABC):
                 batch_id=self.batch_id,
                 item_identifier=item_metadata["item_identifier"],
                 workflow_name=self.workflow_name,
+                source_system_identifier=item_metadata.get("source_system_identifier"),
             )
 
             # attach source metadata

--- a/dsc/workflows/metadata_mapping/archivesspace.json
+++ b/dsc/workflows/metadata_mapping/archivesspace.json
@@ -1,0 +1,21 @@
+{
+  "dc.title": {
+    "source_field_name": "title",
+    "language": "en_US"
+  },
+  "dc.contributor.author": {
+    "source_field_name": "author",
+    "delimiter": "|"
+  },
+  "dc.description": {
+    "source_field_name": "description",
+    "language": "en_US"
+  },
+  "dc.rights": {
+    "source_field_name": "rights_statement",
+    "language": "en_US"
+  },
+  "dc.rights.uri": {
+    "source_field_name": "rights_uri"
+  }
+}

--- a/dsc/workflows/metadata_mapping/archivesspace.json
+++ b/dsc/workflows/metadata_mapping/archivesspace.json
@@ -1,7 +1,6 @@
 {
   "dc.title": {
     "source_field_name": "title",
-    "language": "en_US"
   },
   "dc.contributor.author": {
     "source_field_name": "author",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from dsc.utilities.aws.s3 import S3Client
 from dsc.utilities.aws.ses import SESClient
 from dsc.utilities.aws.sqs import SQSClient
 from dsc.workflows import OpenCourseWare
+from dsc.workflows.archivesspace import ArchivesSpace
 from dsc.workflows.base import Workflow, WorkflowEvents
 from dsc.workflows.base.simple_csv import SimpleCSV
 
@@ -121,6 +122,12 @@ def base_workflow_instance(item_metadata, metadata_mapping, mocked_s3):
 @pytest.fixture
 def simple_csv_workflow_instance(metadata_mapping):
     return TestSimpleCSV(batch_id="batch-aaa")
+
+
+@pytest.fixture
+@freeze_time("2025-01-01 09:00:00")
+def archivesspace_workflow_instance(tmp_path):
+    return ArchivesSpace(batch_id="batch-aaa")
 
 
 @pytest.fixture

--- a/tests/test_item_submission.py
+++ b/tests/test_item_submission.py
@@ -56,8 +56,16 @@ def test_itemsubmission_get_batch_success(mocked_item_submission_db):
 
 def test_itemsubmission_create_success():
     assert ItemSubmission.create(
-        batch_id="batch-aaa", item_identifier="123", workflow_name="test"
-    ) == ItemSubmission(batch_id="batch-aaa", item_identifier="123", workflow_name="test")
+        batch_id="batch-aaa",
+        item_identifier="123",
+        workflow_name="test",
+        source_system_identifier="abcde",
+    ) == ItemSubmission(
+        batch_id="batch-aaa",
+        item_identifier="123",
+        workflow_name="test",
+        source_system_identifier="abcde",
+    )
 
 
 def test_itemsubmission_upsert_db_success(

--- a/tests/test_workflow_archivesspace.py
+++ b/tests/test_workflow_archivesspace.py
@@ -1,0 +1,116 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import smart_open
+from freezegun import freeze_time
+
+from dsc.db.models import ItemSubmissionDB, ItemSubmissionStatus
+
+
+@freeze_time("2025-01-01 09:00:00")
+def test_workflow_specific_processing_success(
+    mocked_item_submission_db,
+    archivesspace_workflow_instance,
+    mocked_s3,
+    s3_client,
+    caplog,
+):
+    caplog.set_level("DEBUG")
+
+    run_date = datetime.now(UTC)
+    run_date_str = run_date.strftime("%Y-%m-%d-%H:%M:%S")
+
+    ItemSubmissionDB.create(
+        item_identifier="123",
+        batch_id="batch-aaa",
+        workflow_name="archivesspace",
+        dspace_handle="handle/123",
+        source_system_identifier="archives/456",
+        status=ItemSubmissionStatus.INGEST_SUCCESS,
+        last_run_date=run_date,
+    )
+    s3_client.client.create_bucket(Bucket="output-bucket")
+
+    archivesspace_workflow_instance.workflow_specific_processing()
+
+    with smart_open.open(
+        f"s3://output-bucket/{archivesspace_workflow_instance.batch_id}-{run_date_str}.csv"
+    ) as csv_file:
+        assert csv_file.read() == "ao_uri,dspace_handle\narchives/456,handle/123\n"
+    assert (
+        f"Completed ingest report for batch '{archivesspace_workflow_instance.batch_id}' "
+        f"on run date '{run_date_str}'" in caplog.text
+    )
+
+
+@freeze_time("2025-01-01 09:00:00")
+def test_workflow_specific_processing_wrong_status_skipped(
+    archivesspace_workflow_instance,
+    mocked_item_submission_db,
+    mocked_s3,
+    s3_client,
+    caplog,
+):
+    caplog.set_level("DEBUG")
+
+    run_date = datetime.now(UTC)
+    run_date_str = run_date.strftime("%Y-%m-%d-%H:%M:%S")
+
+    ItemSubmissionDB.create(
+        item_identifier="123",
+        batch_id="batch-aaa",
+        workflow_name="archivesspace",
+        dspace_handle="handle/123",
+        source_system_identifier="archives/456",
+        status=ItemSubmissionStatus.RECONCILE_SUCCESS,
+        last_run_date=run_date,
+    )
+    s3_client.client.create_bucket(Bucket="output-bucket")
+
+    archivesspace_workflow_instance.workflow_specific_processing()
+
+    with pytest.raises(OSError, match="The specified key does not exist"):
+        smart_open.open(
+            f"s3://output-bucket/{archivesspace_workflow_instance.batch_id}-{run_date_str}.csv"
+        )
+    assert (
+        f"No items ingested for '{archivesspace_workflow_instance.batch_id}' on run "
+        f"date '{run_date_str}'" in caplog.text
+    )
+
+
+@freeze_time("2025-01-01 09:00:00")
+def test_workflow_specific_processing_wrong_date_skipped(
+    archivesspace_workflow_instance,
+    mocked_item_submission_db,
+    mocked_s3,
+    s3_client,
+    caplog,
+):
+    caplog.set_level("DEBUG")
+
+    run_date = datetime.now(UTC)
+    wrong_time = run_date + timedelta(hours=9)
+    run_date_str = run_date.strftime("%Y-%m-%d-%H:%M:%S")
+
+    ItemSubmissionDB.create(
+        item_identifier="123",
+        batch_id="batch-aaa",
+        workflow_name="archivesspace",
+        dspace_handle="handle/123",
+        source_system_identifier="archives/456",
+        status=ItemSubmissionStatus.INGEST_SUCCESS,
+        last_run_date=wrong_time,
+    )
+    s3_client.client.create_bucket(Bucket="output-bucket")
+
+    archivesspace_workflow_instance.workflow_specific_processing()
+
+    with pytest.raises(OSError, match="The specified key does not exist"):
+        smart_open.open(
+            f"s3://output-bucket/{archivesspace_workflow_instance.batch_id}-{run_date_str}.csv"
+        )
+    assert (
+        f"No items ingested for '{archivesspace_workflow_instance.batch_id}' on run "
+        f"date '{run_date_str}'" in caplog.text
+    )


### PR DESCRIPTION
### Purpose and background context
Add `ArchivesSpace` workflow and associated functionality.

I originally was thinking I needed a more invasive approach for generating the ingest report but realize this could all be accomplished with the DynamoDB data. To ensure DSC is only generating a report for items that were successfully ingested on the current run, I’m using the following criteria: 

- The ingest report runs after all results messages are processed and all item submissions are updated in DynamoDB 
- `status` in DynamoDB is set to `INGEST_SUCCESS `
- `run_date` in DynamoDB matches `self.run_date` to ensure it was updated in the current run 

The  check on line 500 of `dsc/workflows/base/__init__.py` ensures anything already set to `INGEST_SUCCESS` will be skipped before the `last_run_date` is set on line 528. Please let me know if there holes in this logic!

### How can a reviewer manually see the effects of these changes?
Not possible at this stage

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
* https://mitlibraries.atlassian.net/browse/IN-1100


### Developer
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [ ] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

