### PR TITLE
In 1460 add batch creation report

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,6 @@ repos:
         types: ["python"]
       - id: pip-audit
         name: pip-audit
-        entry: pipenv run pip-audit
+        entry: pipenv run pip-audit --ignore-vuln GHSA-4xh5-x5gv-qwph
         language: system
         pass_filenames: false

--- a/Pipfile
+++ b/Pipfile
@@ -19,7 +19,6 @@ black = "*"
 coveralls = "*"
 freezegun = "*"
 moto = {version="*", extras=["server"]}
-
 mypy = "*"
 pandas-stubs = "*"
 pip-audit = "*"

--- a/dsc/item_submission.py
+++ b/dsc/item_submission.py
@@ -66,6 +66,9 @@ class ItemSubmission:
     bitstream_s3_uris: list[str] | None = None
     metadata_s3_uri: str = ""
 
+    def asdict_subset(self, fields: list[str]) -> dict:
+        return {field: getattr(self, field) for field in fields if hasattr(self, field)}
+
     @classmethod
     def get_or_create(
         cls,

--- a/dsc/reports/__init__.py
+++ b/dsc/reports/__init__.py
@@ -1,6 +1,13 @@
 from dsc.reports.base import Report
+from dsc.reports.create_batch import CreateBatchReport
 from dsc.reports.finalize import FinalizeReport
 from dsc.reports.reconcile import ReconcileReport
 from dsc.reports.submit import SubmitReport
 
-__all__ = ["FinalizeReport", "ReconcileReport", "Report", "SubmitReport"]
+__all__ = [
+    "CreateBatchReport",
+    "FinalizeReport",
+    "ReconcileReport",
+    "Report",
+    "SubmitReport",
+]

--- a/dsc/reports/create_batch.py
+++ b/dsc/reports/create_batch.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import datetime
+import logging
+from io import StringIO
+from typing import TYPE_CHECKING, ClassVar
+
+import boto3
+import pandas as pd
+from jinja2 import Environment, FileSystemLoader, Template, select_autoescape
+
+from dsc.config import Config
+from dsc.item_submission import ItemSubmission
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from dsc import workflows
+
+logger = logging.getLogger(__name__)
+CONFIG = Config()
+
+
+class CreateBatchReport:
+    """Report class for Workflow.create_batch method.
+
+    The email created by this report is structured as follows:
+
+    1. A message summarizing the number of successfully created item
+       submissions in DynamoDB.
+    2. A CSV file containing all item submissions for a given batch
+       that were written to DynamoDB.
+    """
+
+    fields: ClassVar[list[str]] = [
+        "batch_id",
+        "item_identifier",
+        "source_system_identifier",
+        "status",
+        "status_details",
+        "dspace_handle",
+        "ingest_date",
+    ]
+
+    def __init__(self, workflow_name: str, batch_id: str):
+        self.workflow_name = workflow_name
+        self.batch_id = batch_id
+        self.client = boto3.client("dynamodb")
+        self.report_date = datetime.datetime.now(tz=datetime.UTC).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+        # configure environment for loading jinja templates
+        self.jinja_env = Environment(
+            loader=FileSystemLoader("dsc/reports/templates/"),
+            autoescape=select_autoescape(),
+        )
+
+        # cache list of item submissions
+        self._item_submissions: list[dict] | None = None
+
+    @property
+    def summary_template(self) -> Template:
+        """Jinja template for report summary."""
+        return self.jinja_env.get_template("create_batch_report.txt")
+
+    @property
+    def subject(self) -> str:
+        """Subject heading for report used ijn email."""
+        return f"DSC Create Batch Results - {self.workflow_name}, batch='{self.batch_id}'"
+
+    @property
+    def item_submissions(self) -> list[dict]:
+        """Report data retrieved from DynamoDB.
+
+        An effect of running Workflow.create_batch is the writing of item submissions
+        to DynamoDB. Therefore, this report reads the following data from DynamoDB:
+
+        - All item submissions for a given batch
+        """
+        if not self._item_submissions:
+            self._item_submissions = [
+                item_submission.asdict_subset(fields=self.fields)
+                for item_submission in ItemSubmission.get_batch(self.batch_id)
+            ]
+        return self._item_submissions
+
+    @classmethod
+    def from_workflow(cls, workflow: workflows.Workflow) -> CreateBatchReport:
+        """Create instance of Report using dsc.workflows.Workflow."""
+        return cls(
+            workflow_name=workflow.workflow_name,
+            batch_id=workflow.batch_id,
+        )
+
+    def generate_summary(self) -> str:
+        """Render summary from report template.
+
+        The generated summary will be used as the email message body.
+        """
+        return self.summary_template.render(
+            batch_id=self.batch_id,
+            report_date=self.report_date,
+            item_submissions=self.item_submissions,
+        )
+
+    def create_email_attachments(self) -> list[tuple]:
+        """Create attachments to include in report email."""
+        return [("create_batch_results.csv", self.write_to_csv(output_file=StringIO()))]
+
+    def write_to_csv(self, output_file: StringIO | str | Path) -> StringIO | str | Path:
+        """Write report data to either a CSV file or in-memory string buffer."""
+        if isinstance(output_file, StringIO):
+            logger.debug("Writing data to CSV buffer")
+        else:
+            logger.debug("Writing data to CSV file: %s", output_file)
+        pd.DataFrame(self.item_submissions).to_csv(output_file, index=False)
+        return output_file

--- a/dsc/reports/templates/create_batch_report.txt
+++ b/dsc/reports/templates/create_batch_report.txt
@@ -1,0 +1,8 @@
+{% block content %}
+Create batch report
+Batch: {{batch_id}}
+Run date: {{report_date}}
+
+Results:
+Created: {{ item_submissions | length }}
+{% endblock %}

--- a/dsc/utilities/aws/ses.py
+++ b/dsc/utilities/aws/ses.py
@@ -1,3 +1,4 @@
+# ruff: noqa: FIX002, TD002, TD003
 from __future__ import annotations
 
 import logging
@@ -55,6 +56,11 @@ class SESClient:
         message_body_html: str | None = None,
         attachments: list | None = None,
     ) -> MIMEMultipart:
+        # TODO: Simplify method to simply accept 'message_body' as plain text
+        #       after all reporting modules updated to read from DynamoDB.
+        #       Initial testing showed that including the message as HTML was
+        #       resulted in a separate HTML file being added as an attachment
+        #       instead of formatting the email body.
         message = MIMEMultipart()
         message["Subject"] = subject
 
@@ -70,6 +76,7 @@ class SESClient:
         return message
 
     def _create_attachment(self, filename: str, content: StringIO) -> MIMEApplication:
+        content.seek(0)
         attachment = MIMEApplication(content.read())
         attachment.add_header("Content-Disposition", "attachment", filename=filename)
         return attachment

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from moto import mock_aws
 from moto.server import ThreadedMotoServer
 
 from dsc.config import Config
-from dsc.db.models import ItemSubmissionDB
+from dsc.db.models import ItemSubmissionDB, ItemSubmissionStatus
 from dsc.item_submission import ItemSubmission
 from dsc.utilities.aws.s3 import S3Client
 from dsc.utilities.aws.ses import SESClient
@@ -236,6 +236,23 @@ def mocked_item_submission_db(config_instance):
             ItemSubmissionDB.set_table_name(config_instance.item_submissions_table_name)
             ItemSubmissionDB.create_table()
         yield
+
+
+@pytest.fixture
+def mock_item_submission_db_with_records(mocked_item_submission_db):
+    # create two records for 'batch-aaa'
+    ItemSubmissionDB(
+        batch_id="aaa",
+        item_identifier="123",
+        workflow_name="test",
+        status=ItemSubmissionStatus.BATCH_CREATED,
+    ).create()
+    ItemSubmissionDB(
+        batch_id="aaa",
+        item_identifier="456",
+        workflow_name="test",
+        status=ItemSubmissionStatus.BATCH_CREATED,
+    ).create()
 
 
 @pytest.fixture


### PR DESCRIPTION
### Purpose and background context
Reporting is required for the recently added batch creation step, which assumes the responsibility of recording
item submissions to DynamoDB (previously handled by the reconcile step). This also marks an important shift to retrieve reporting data from DynamoDB instead of the WorkflowEvents module.

### How can a reviewer manually see the effects of these changes?
As work to migrate DSC -> DSO (infrastructure) begins, it might be tricky to test sending of actual emails. Review of new unit tests is sufficient.

### Includes new or updated dependencies?
NO - The first commit ignores the vulnerability raised by `pip-audit`.

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1460