### PR TITLE
Add metrics client

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,29 +1,28 @@
 default_language_version:
-  python: python3.12 # set for project python version
+  python: python3.12
+default_stages:
+  - pre-push
 repos:
   - repo: local
     hooks:
-      - id: black-apply
-        name: black-apply
-        entry: uv run black
+      - id: ruff-format
+        name: ruff-format
+        entry: uv run ruff format --diff
         language: system
         pass_filenames: true
-        types: ["python"]
+        types: [ "python" ]
+
       - id: mypy
         name: mypy
         entry: uv run mypy
         language: system
         pass_filenames: true
-        types: ["python"]
-        exclude: "tests/"
-      - id: ruff-apply
-        name: ruff-apply
-        entry: uv run ruff check --fix
+        types: [ "python" ]
+        exclude: "(tests/|output/|migrations/)"
+
+      - id: ruff-check
+        name: ruff-check
+        entry: uv run ruff check
         language: system
         pass_filenames: true
-        types: ["python"]
-      - id: pip-audit
-        name: pip-audit
-        entry: uv run pip-audit
-        language: system
-        pass_filenames: false
+        types: [ "python" ]

--- a/dsc/config.py
+++ b/dsc/config.py
@@ -5,6 +5,15 @@ from collections.abc import Iterable
 
 import sentry_sdk
 
+METRICS_NAMESPACE = "dso"
+
+METRICS = [
+    "item_submitted",  # item submitted to DSS
+    "submission_error",  # error during submission to DSS
+    "ingested_item",  # item ingested successfully into DSpace
+    "ingest_error",  # error during attempted item ingest into DSpace
+]
+
 
 class Config:
     REQUIRED_ENV_VARS: Iterable[str] = [

--- a/dsc/config.py
+++ b/dsc/config.py
@@ -7,12 +7,12 @@ import sentry_sdk
 
 METRICS_NAMESPACE = "dso"
 
-METRICS = [
+ALLOWED_METRICS = {
     "item_submitted",  # item submitted to DSS
     "submission_error",  # error during submission to DSS
     "ingested_item",  # item ingested successfully into DSpace
     "ingest_error",  # error during attempted item ingest into DSpace
-]
+}
 
 
 class Config:

--- a/dsc/utils/aws/__init__.py
+++ b/dsc/utils/aws/__init__.py
@@ -1,5 +1,6 @@
+from dsc.utils.aws.metrics import MetricsClient
 from dsc.utils.aws.s3 import S3Client
 from dsc.utils.aws.ses import SESClient
 from dsc.utils.aws.sqs import SQSClient
 
-__all__ = ["S3Client", "SESClient", "SQSClient"]
+__all__ = ["MetricsClient", "S3Client", "SESClient", "SQSClient"]

--- a/dsc/utils/aws/__init__.py
+++ b/dsc/utils/aws/__init__.py
@@ -1,6 +1,6 @@
-from dsc.utils.aws.metrics import MetricsClient
+from dsc.utils.aws.metrics import Metric, MetricsClient
 from dsc.utils.aws.s3 import S3Client
 from dsc.utils.aws.ses import SESClient
 from dsc.utils.aws.sqs import SQSClient
 
-__all__ = ["MetricsClient", "S3Client", "SESClient", "SQSClient"]
+__all__ = ["Metric", "MetricsClient", "S3Client", "SESClient", "SQSClient"]

--- a/dsc/utils/aws/metrics.py
+++ b/dsc/utils/aws/metrics.py
@@ -1,0 +1,198 @@
+"""AWS CloudWatch metrics client for workflow submission tracking."""
+
+from __future__ import annotations
+
+import logging
+
+import boto3
+
+from dsc.config import METRICS, METRICS_NAMESPACE
+
+logger = logging.getLogger(__name__)
+
+
+UNIT_VALUES = frozenset(
+    [
+        "Seconds",
+        "Microseconds",
+        "Milliseconds",
+        "Bytes",
+        "Kilobytes",
+        "Megabytes",
+        "Gigabytes",
+        "Terabytes",
+        "Bits",
+        "Kilobits",
+        "Megabits",
+        "Gigabits",
+        "Terabits",
+        "Percent",
+        "Count",
+        "Bytes/Second",
+        "Kilobytes/Second",
+        "Megabytes/Second",
+        "Gigabytes/Second",
+        "Terabytes/Second",
+        "Bits/Second",
+        "Kilobits/Second",
+        "Megabits/Second",
+        "Gigabits/Second",
+        "Terabits/Second",
+        "Count/Second",
+    ]
+)
+
+
+class MetricsClient:
+    """A simple client to record metrics to AWS CloudWatch."""
+
+    def __init__(self) -> None:
+        """Initialize the MetricsClient."""
+        self.cloudwatch = boto3.client("cloudwatch")
+        self.batch_metrics: list[dict] = []
+
+    def publish_single_metric(
+        self,
+        metric_name: str,
+        value: int,
+        unit: str,
+        metric_dimensions: dict[str, str] | None = None,
+    ) -> None:
+        """Publish a single metric to CloudWatch.
+
+        Args:
+            metric_name: The name of the metric to publish.
+            value: The value of the metric.
+            unit: The unit of the metric.
+            metric_dimensions: Optional dictionary of dimension names and values.
+
+        Raises:
+            ValueError: If unit is invalid.
+        """
+        metric_data = self._validate_and_build_metric_data(
+            metric_name, value, unit, metric_dimensions
+        )
+        self._push_metric_data([metric_data])
+
+    def _validate_and_build_metric_data(
+        self,
+        metric_name: str,
+        value: int,
+        unit: str,
+        metric_dimensions: dict[str, str] | None = None,
+    ) -> dict:
+        """Validate and build a metric data dictionary for CloudWatch.
+
+        Args:
+            metric_name: The name of the metric.
+            value: The value of the metric.
+            unit: The unit of the metric.
+            metric_dimensions: Optional dictionary of dimension names and values.
+
+        Returns:
+            A metric data dictionary formatted for CloudWatch.
+        """
+        self._approved_metric(metric_name)
+        self._validate_unit(unit)
+        dimensions = [
+            {"Name": name, "Value": dim_value}
+            for name, dim_value in (
+                metric_dimensions.items() if metric_dimensions else []
+            )
+        ]
+        return {
+            "MetricName": metric_name,
+            "Value": value,
+            "Unit": unit,
+            "Dimensions": dimensions,
+        }
+
+    def _approved_metric(self, metric_name: str) -> bool:
+        """Check if a metric name is in the approved list of metrics for the application.
+
+        Args:
+            metric_name: The name of the metric to check.
+        """
+        if metric_name not in METRICS:
+            raise ValueError(
+                f"Metric name '{metric_name}' is not in the approved list of metrics: "
+                f"{', '.join(METRICS)}"
+            )
+        return True
+
+    def _validate_unit(self, unit: str) -> None:
+        """Validate that metric unit is allowed by AWS CloudWatch.
+
+        Args:
+            unit: The unit to validate.
+
+        Raises:
+            ValueError: If unit is not allowed by AWS CloudWatch.
+        """
+        if unit not in UNIT_VALUES:
+            raise ValueError(
+                f"Invalid unit '{unit}'. Must be one of: {', '.join(UNIT_VALUES)}"
+            )
+
+    def _push_metric_data(self, metric_data: list[dict]) -> None:
+        """Push metric data to CloudWatch.
+
+        Args:
+            metric_data: List of metric dictionaries to push.
+        """
+        try:
+            self.cloudwatch.put_metric_data(
+                Namespace=METRICS_NAMESPACE, MetricData=metric_data
+            )
+            logger.info(f"Published metric with {metric_data} to CloudWatch.")
+        except Exception:
+            logger.exception(
+                f"Failed to publish metric with {metric_data} to CloudWatch."
+            )
+
+    def add_metric_to_batch(
+        self,
+        metric_name: str,
+        value: int,
+        unit: str,
+        metric_dimensions: dict[str, str] | None = None,
+    ) -> None:
+        """Add a metric to the batch for later publishing.
+
+        Args:
+            metric_name: The name of the metric.
+            value: The value of the metric.
+            unit: The unit of the metric.
+            metric_dimensions: Optional dictionary of dimension names and values.
+
+        Raises:
+            ValueError: If unit is invalid.
+        """
+        metric_data = self._validate_and_build_metric_data(
+            metric_name, value, unit, metric_dimensions
+        )
+        self.batch_metrics.append(metric_data)
+
+    def publish_batch_metrics(self, batch_size: int = 20) -> None:
+        """Publish all accumulated batch metrics to CloudWatch.
+
+        Raises:
+            ValueError: If any metric has an invalid unit or missing required fields.
+        """
+        if not self.batch_metrics:
+            logger.info("No metrics to publish.")
+            return
+
+        # Validate all metrics before publishing
+        for metric in self.batch_metrics:
+            if not all(key in metric for key in ["MetricName", "Value", "Unit"]):
+                raise ValueError(
+                    f"Each metric must contain 'MetricName', 'Value', and 'Unit'. "
+                    f"Invalid metric: {metric}"
+                )
+            self._approved_metric(metric["MetricName"])
+            self._validate_unit(metric["Unit"])
+
+        for x in range(0, len(self.batch_metrics), batch_size):
+            self._push_metric_data(self.batch_metrics[x : x + batch_size])
+        self.batch_metrics.clear()

--- a/dsc/utils/aws/metrics.py
+++ b/dsc/utils/aws/metrics.py
@@ -116,9 +116,8 @@ class MetricsClient:
             ValueError: If unit is not allowed by AWS CloudWatch.
         """
         if unit not in UNIT_VALUES:
-            raise ValueError(
-                f"Invalid unit '{unit}'. Must be one of: {', '.join(sorted(UNIT_VALUES))}"
-            )
+            allowed_units = ", ".join(sorted(UNIT_VALUES))
+            raise ValueError(f"Invalid unit '{unit}'. Must be one of: {allowed_units}")
         return True
 
     def _publish_metrics(self, metrics: list[Metric]) -> None:

--- a/dsc/utils/aws/metrics.py
+++ b/dsc/utils/aws/metrics.py
@@ -56,7 +56,9 @@ class Metric:
 class MetricsClient:
     """A simple client to record metrics to AWS CloudWatch."""
 
-    def __init__(self, namespace: str, allowed_metrics: set[str] | None = None) -> None:
+    def __init__(
+        self, namespace: str | None = None, allowed_metrics: set[str] | None = None
+    ) -> None:
         """Initialize the MetricsClient."""
         self.namespace = namespace
         self.allowed_metrics: set[str] | None = allowed_metrics

--- a/dsc/utils/aws/metrics.py
+++ b/dsc/utils/aws/metrics.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 
 import boto3
 
-from dsc.config import METRICS, METRICS_NAMESPACE
+from dsc.config import METRICS_NAMESPACE
 
 logger = logging.getLogger(__name__)
 
@@ -43,84 +44,66 @@ UNIT_VALUES = frozenset(
 )
 
 
+@dataclass
+class Metric:
+    """A class representing a single metric to be published to CloudWatch."""
+
+    name: str
+    value: int
+    unit: str
+    dimensions: dict[str, str] | None = None
+
+
 class MetricsClient:
     """A simple client to record metrics to AWS CloudWatch."""
 
-    def __init__(self) -> None:
+    def __init__(self, allowed_metrics: set[str] | None = None) -> None:
         """Initialize the MetricsClient."""
-        self.cloudwatch = boto3.client("cloudwatch")
-        self.batch_metrics: list[dict] = []
+        self.namespace = METRICS_NAMESPACE
+        self.allowed_metrics: set[str] | None = allowed_metrics
+        self._cloudwatch = boto3.client("cloudwatch")
+        self.batch_metrics: list[Metric] = []
 
     def publish_single_metric(
         self,
-        metric_name: str,
-        value: int,
-        unit: str,
-        metric_dimensions: dict[str, str] | None = None,
+        metric: Metric,
     ) -> None:
-        """Publish a single metric to CloudWatch.
+        """Publish a single metric to CloudWatch."""
+        self._validate_metric(metric)
+        self._push_metric_data([metric])
 
-        Args:
-            metric_name: The name of the metric to publish.
-            value: The value of the metric.
-            unit: The unit of the metric.
-            metric_dimensions: Optional dictionary of dimension names and values.
-
-        Raises:
-            ValueError: If unit is invalid.
-        """
-        metric_data = self._validate_and_build_metric_data(
-            metric_name, value, unit, metric_dimensions
-        )
-        self._push_metric_data([metric_data])
-
-    def _validate_and_build_metric_data(
+    def _validate_metric(
         self,
-        metric_name: str,
-        value: int,
-        unit: str,
-        metric_dimensions: dict[str, str] | None = None,
-    ) -> dict:
-        """Validate and build a metric data dictionary for CloudWatch.
+        metric: Metric,
+    ) -> bool:
+        """Validate that a metric has required fields and allowed unit.
 
         Args:
-            metric_name: The name of the metric.
-            value: The value of the metric.
-            unit: The unit of the metric.
-            metric_dimensions: Optional dictionary of dimension names and values.
-
-        Returns:
-            A metric data dictionary formatted for CloudWatch.
+            metric: The Metric instance to validate.
         """
-        self._approved_metric(metric_name)
-        self._validate_unit(unit)
-        dimensions = [
-            {"Name": name, "Value": dim_value}
-            for name, dim_value in (
-                metric_dimensions.items() if metric_dimensions else []
+        if not all(hasattr(metric, attr) for attr in ["name", "value", "unit"]):
+            raise ValueError(
+                f"Metric must have 'name', 'value', and 'unit' attributes. Invalid "
+                f"metric: {metric}"
             )
-        ]
-        return {
-            "MetricName": metric_name,
-            "Value": value,
-            "Unit": unit,
-            "Dimensions": dimensions,
-        }
+        self._allowed_metric(metric.name)
+        self._validate_metric_unit(metric.unit)
+        return True
 
-    def _approved_metric(self, metric_name: str) -> bool:
-        """Check if a metric name is in the approved list of metrics for the application.
+    def _allowed_metric(self, metric_name: str) -> bool:
+        """Check if a metric name is in the allowed list of metrics for the application.
 
         Args:
             metric_name: The name of the metric to check.
         """
-        if metric_name not in METRICS:
+        if self.allowed_metrics and metric_name not in self.allowed_metrics:
             raise ValueError(
-                f"Metric name '{metric_name}' is not in the approved list of metrics: "
-                f"{', '.join(METRICS)}"
+                f"Metric name '{metric_name}' is not in the allowed list of metrics: "
+                f"{', '.join(self.allowed_metrics)}"
             )
         return True
 
-    def _validate_unit(self, unit: str) -> None:
+    def _validate_metric_unit(self, unit: str) -> bool:
         """Validate that metric unit is allowed by AWS CloudWatch.
 
         Args:
@@ -133,66 +116,75 @@ class MetricsClient:
             raise ValueError(
                 f"Invalid unit '{unit}'. Must be one of: {', '.join(UNIT_VALUES)}"
             )
+        return True
 
-    def _push_metric_data(self, metric_data: list[dict]) -> None:
-        """Push metric data to CloudWatch.
+    def _push_metric_data(self, metrics: list[Metric]) -> None:
+        """Push metrics to CloudWatch.
 
         Args:
-            metric_data: List of metric dictionaries to push.
+            metrics: List of metric instances to push.
         """
+        if not metrics:
+            logger.info("No metrics to publish.")
+            return
+
         try:
-            self.cloudwatch.put_metric_data(
-                Namespace=METRICS_NAMESPACE, MetricData=metric_data
+            metric_data = []
+            for metric in metrics:
+                metric_dict = {
+                    "MetricName": metric.name,
+                    "Value": metric.value,
+                    "Unit": metric.unit,
+                }
+                if metric.dimensions:
+                    metric_dict["Dimensions"] = [
+                        {"Name": key, "Value": value}
+                        for key, value in metric.dimensions.items()
+                    ]
+                metric_data.append(metric_dict)
+
+            self._cloudwatch.put_metric_data(
+                Namespace=self.namespace,
+                MetricData=metric_data,
             )
-            logger.info(f"Published metric with {metric_data} to CloudWatch.")
+            logger.info(
+                f"Published {len(metrics)} metric(s) to CloudWatch namespace "
+                f"'{self.namespace}'."
+            )
         except Exception:
             logger.exception(
-                f"Failed to publish metric with {metric_data} to CloudWatch."
+                f"Failed to publish {len(metrics)} metric(s) to CloudWatch: "
             )
+            raise
 
-    def add_metric_to_batch(
-        self,
-        metric_name: str,
-        value: int,
-        unit: str,
-        metric_dimensions: dict[str, str] | None = None,
-    ) -> None:
-        """Add a metric to the batch for later publishing.
+    def add_metric_to_batch(self, metric: Metric) -> None:
+        """Add a metric to the batch queue.
 
         Args:
-            metric_name: The name of the metric.
-            value: The value of the metric.
-            unit: The unit of the metric.
-            metric_dimensions: Optional dictionary of dimension names and values.
-
-        Raises:
-            ValueError: If unit is invalid.
+            metric: The metric to add to the batch.
         """
-        metric_data = self._validate_and_build_metric_data(
-            metric_name, value, unit, metric_dimensions
-        )
-        self.batch_metrics.append(metric_data)
+        self._validate_metric(metric)
+        self.batch_metrics.append(metric)
 
     def publish_batch_metrics(self, batch_size: int = 20) -> None:
-        """Publish all accumulated batch metrics to CloudWatch.
+        """Publish a batch of metrics to CloudWatch.
 
-        Raises:
-            ValueError: If any metric has an invalid unit or missing required fields.
+        Clears the batch queue after publishing.
+
+        Args:
+            batch_size: Number of metrics to publish in each batch.
         """
         if not self.batch_metrics:
             logger.info("No metrics to publish.")
             return
 
-        # Validate all metrics before publishing
-        for metric in self.batch_metrics:
-            if not all(key in metric for key in ["MetricName", "Value", "Unit"]):
-                raise ValueError(
-                    f"Each metric must contain 'MetricName', 'Value', and 'Unit'. "
-                    f"Invalid metric: {metric}"
-                )
-            self._approved_metric(metric["MetricName"])
-            self._validate_unit(metric["Unit"])
+        try:
+            # Re-validate all metrics before publishing to CloudWatch
+            for metric in self.batch_metrics:
+                self._validate_metric(metric)
 
-        for x in range(0, len(self.batch_metrics), batch_size):
-            self._push_metric_data(self.batch_metrics[x : x + batch_size])
-        self.batch_metrics.clear()
+            for x in range(0, len(self.batch_metrics), batch_size):
+                batch = self.batch_metrics[x : x + batch_size]
+                self._push_metric_data(batch)
+        finally:
+            self.batch_metrics.clear()

--- a/dsc/utils/aws/metrics.py
+++ b/dsc/utils/aws/metrics.py
@@ -7,8 +7,6 @@ from dataclasses import dataclass
 
 import boto3
 
-from dsc.config import METRICS_NAMESPACE
-
 logger = logging.getLogger(__name__)
 
 
@@ -52,25 +50,26 @@ class Metric:
     value: int
     unit: str
     dimensions: dict[str, str] | None = None
+    namespace: str | None = None
 
 
 class MetricsClient:
     """A simple client to record metrics to AWS CloudWatch."""
 
-    def __init__(self, allowed_metrics: set[str] | None = None) -> None:
+    def __init__(self, namespace: str, allowed_metrics: set[str] | None = None) -> None:
         """Initialize the MetricsClient."""
-        self.namespace = METRICS_NAMESPACE
+        self.namespace = namespace
         self.allowed_metrics: set[str] | None = allowed_metrics
         self._cloudwatch = boto3.client("cloudwatch")
         self.batch_metrics: list[Metric] = []
 
-    def publish_single_metric(
+    def publish_metric(
         self,
         metric: Metric,
     ) -> None:
         """Publish a single metric to CloudWatch."""
         self._validate_metric(metric)
-        self._push_metric_data([metric])
+        self._publish_metrics([metric])
 
     def _validate_metric(
         self,
@@ -118,7 +117,7 @@ class MetricsClient:
             )
         return True
 
-    def _push_metric_data(self, metrics: list[Metric]) -> None:
+    def _publish_metrics(self, metrics: list[Metric]) -> None:
         """Push metrics to CloudWatch.
 
         Args:
@@ -127,10 +126,10 @@ class MetricsClient:
         if not metrics:
             logger.info("No metrics to publish.")
             return
-
         try:
             metric_data = []
             for metric in metrics:
+                self._validate_namespace(metric)
                 metric_dict = {
                     "MetricName": metric.name,
                     "Value": metric.value,
@@ -144,7 +143,7 @@ class MetricsClient:
                 metric_data.append(metric_dict)
 
             self._cloudwatch.put_metric_data(
-                Namespace=self.namespace,
+                Namespace=metric.namespace or self.namespace,
                 MetricData=metric_data,
             )
             logger.info(
@@ -157,16 +156,26 @@ class MetricsClient:
             )
             raise
 
-    def add_metric_to_batch(self, metric: Metric) -> None:
-        """Add a metric to the batch queue.
+    def _validate_namespace(self, metric: Metric) -> bool:
+        """Validate metric has a namespace or the client has a default namespace."""
+        if not metric.namespace and not self.namespace:
+            raise ValueError(
+                f"Metric '{metric.name}' must have a namespace if no default "
+                f"namespace is set for the MetricsClient."
+            )
+        return True
+
+    def add_metrics_to_batch(self, metrics: list[Metric]) -> None:
+        """Add metrics to the batch queue.
 
         Args:
-            metric: The metric to add to the batch.
+            metrics: The metrics to add to the batch.
         """
-        self._validate_metric(metric)
-        self.batch_metrics.append(metric)
+        for metric in metrics:
+            self._validate_metric(metric)
+            self.batch_metrics.append(metric)
 
-    def publish_batch_metrics(self, batch_size: int = 20) -> None:
+    def publish_metrics_batch(self, batch_size: int = 20) -> None:
         """Publish a batch of metrics to CloudWatch.
 
         Clears the batch queue after publishing.
@@ -179,12 +188,8 @@ class MetricsClient:
             return
 
         try:
-            # Re-validate all metrics before publishing to CloudWatch
-            for metric in self.batch_metrics:
-                self._validate_metric(metric)
-
             for x in range(0, len(self.batch_metrics), batch_size):
                 batch = self.batch_metrics[x : x + batch_size]
-                self._push_metric_data(batch)
+                self._publish_metrics(batch)
         finally:
             self.batch_metrics.clear()

--- a/dsc/utils/aws/metrics.py
+++ b/dsc/utils/aws/metrics.py
@@ -9,35 +9,37 @@ import boto3
 
 logger = logging.getLogger(__name__)
 
+CLOUDWATCH_METRICS_LIMIT = 1000
 
 UNIT_VALUES = frozenset(
     [
-        "Seconds",
-        "Microseconds",
-        "Milliseconds",
-        "Bytes",
-        "Kilobytes",
-        "Megabytes",
-        "Gigabytes",
-        "Terabytes",
         "Bits",
-        "Kilobits",
-        "Megabits",
-        "Gigabits",
-        "Terabits",
-        "Percent",
-        "Count",
-        "Bytes/Second",
-        "Kilobytes/Second",
-        "Megabytes/Second",
-        "Gigabytes/Second",
-        "Terabytes/Second",
         "Bits/Second",
-        "Kilobits/Second",
-        "Megabits/Second",
-        "Gigabits/Second",
-        "Terabits/Second",
+        "Bytes",
+        "Bytes/Second",
+        "Count",
         "Count/Second",
+        "Gigabits",
+        "Gigabits/Second",
+        "Gigabytes",
+        "Gigabytes/Second",
+        "Kilobits",
+        "Kilobits/Second",
+        "Kilobytes",
+        "Kilobytes/Second",
+        "Megabits",
+        "Megabits/Second",
+        "Megabytes",
+        "Megabytes/Second",
+        "Milliseconds",
+        "Microseconds",
+        "None",
+        "Percent",
+        "Seconds",
+        "Terabits",
+        "Terabits/Second",
+        "Terabytes",
+        "Terabytes/Second",
     ]
 )
 
@@ -115,23 +117,43 @@ class MetricsClient:
         """
         if unit not in UNIT_VALUES:
             raise ValueError(
-                f"Invalid unit '{unit}'. Must be one of: {', '.join(UNIT_VALUES)}"
+                f"Invalid unit '{unit}'. Must be one of: {', '.join(sorted(UNIT_VALUES))}"
             )
         return True
 
     def _publish_metrics(self, metrics: list[Metric]) -> None:
-        """Push metrics to CloudWatch.
+        """Publish metrics to CloudWatch.
+
+        Automatically chunks metrics if the list exceeds CloudWatch's limit
+        of 1000 metrics per request.
 
         Args:
-            metrics: List of metric instances to push.
+            metrics: List of metric instances to publish.
         """
         if not metrics:
             logger.info("No metrics to publish.")
             return
+
+        # Defensively chunk metrics if they exceed CloudWatch's limit
+        if len(metrics) > CLOUDWATCH_METRICS_LIMIT:
+            logger.info(
+                f"Splitting {len(metrics)} metrics into chunks of "
+                f"{CLOUDWATCH_METRICS_LIMIT} for CloudWatch compliance."
+            )
+            for i in range(0, len(metrics), CLOUDWATCH_METRICS_LIMIT):
+                chunk = metrics[i : i + CLOUDWATCH_METRICS_LIMIT]
+                self._publish_metrics(chunk)
+            return
+
         try:
+            # Validate all metrics and ensure consistent namespace
+            namespaces = set()
             metric_data = []
             for metric in metrics:
                 self._validate_namespace(metric)
+                selected_namespace = metric.namespace or self.namespace
+                namespaces.add(selected_namespace)
+
                 metric_dict = {
                     "MetricName": metric.name,
                     "Value": metric.value,
@@ -144,13 +166,21 @@ class MetricsClient:
                     ]
                 metric_data.append(metric_dict)
 
+            # Ensure all metrics resolve to the same namespace
+            if len(namespaces) > 1:
+                raise ValueError(  # noqa: TRY301
+                    f"Cannot publish metrics with different namespaces in a single "
+                    f"request. Found: {namespaces}"
+                )
+
+            selected_namespace = namespaces.pop()
             self._cloudwatch.put_metric_data(
-                Namespace=metric.namespace or self.namespace,
+                Namespace=selected_namespace,
                 MetricData=metric_data,
             )
             logger.info(
                 f"Published {len(metrics)} metric(s) to CloudWatch namespace "
-                f"'{self.namespace}'."
+                f"'{selected_namespace}'."
             )
         except Exception:
             logger.exception(
@@ -180,10 +210,15 @@ class MetricsClient:
     def publish_metrics_batch(self, batch_size: int = 20) -> None:
         """Publish a batch of metrics to CloudWatch.
 
-        Clears the batch queue after publishing.
+        Clears the batch queue after successful publishing.
 
         Args:
-            batch_size: Number of metrics to publish in each batch.
+            batch_size: Number of metrics to publish in each batch. Must be less than
+            CloudWatch's limit of 1000 metrics per request.
+
+        Raises:
+            Exception: If publishing fails, metrics remain in the batch queue
+                for retry or manual handling.
         """
         if not self.batch_metrics:
             logger.info("No metrics to publish.")
@@ -193,5 +228,10 @@ class MetricsClient:
             for x in range(0, len(self.batch_metrics), batch_size):
                 batch = self.batch_metrics[x : x + batch_size]
                 self._publish_metrics(batch)
-        finally:
-            self.batch_metrics.clear()
+        except Exception:
+            # Keep only the unpublished metrics (starting from the failed batch)
+            self.batch_metrics = self.batch_metrics[x:]
+            raise
+
+        # Clear only if all batches published successfully
+        self.batch_metrics.clear()

--- a/dsc/workflows/base/workflow.py
+++ b/dsc/workflows/base/workflow.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, final
 import jsonschema
 import jsonschema.exceptions
 
-from dsc.config import Config
+from dsc.config import ALLOWED_METRICS, Config
 from dsc.db.models import ItemSubmissionStatus
 from dsc.exceptions import (
     BatchCreationFailedError,
@@ -19,7 +19,7 @@ from dsc.exceptions import (
 )
 from dsc.item_submission import ItemSubmission
 from dsc.reports import CreateReport, FinalizeReport, SubmitReport
-from dsc.utils.aws import MetricsClient, SESClient, SQSClient
+from dsc.utils.aws import Metric, MetricsClient, SESClient, SQSClient
 from dsc.utils.validate.schemas import RESULT_MESSAGE_ATTRIBUTES, RESULT_MESSAGE_BODY
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -130,7 +130,7 @@ class Workflow(ABC):
             "skipped": 0,
             "errors": 0,
         }
-        self.metrics_client = MetricsClient()
+        self.metrics_client = MetricsClient(allowed_metrics=ALLOWED_METRICS)
         self.metrics_dimensions = {
             "application": "dsc",
             "workflow_name": self.workflow_name,
@@ -334,10 +334,12 @@ class Workflow(ABC):
                 item_submission.submit_attempts += 1
                 item_submission.upsert_db()
                 self.metrics_client.publish_single_metric(
-                    metric_name="item_submitted",
-                    value=1,
-                    unit="Count",
-                    metric_dimensions=self.metrics_dimensions,
+                    Metric(
+                        name="item_submitted",
+                        value=1,
+                        unit="Count",
+                        dimensions=self.metrics_dimensions,
+                    )
                 )
             except NotImplementedError:
                 raise
@@ -349,10 +351,12 @@ class Workflow(ABC):
                 item_submission.upsert_db()
 
                 self.metrics_client.publish_single_metric(
-                    metric_name="submission_error",
-                    value=1,
-                    unit="Count",
-                    metric_dimensions=self.metrics_dimensions,
+                    Metric(
+                        name="submission_error",
+                        value=1,
+                        unit="Count",
+                        dimensions=self.metrics_dimensions,
+                    )
                 )
 
         logger.info(
@@ -441,10 +445,12 @@ class Workflow(ABC):
                 logger.debug(f"Record {log_str} was ingested")
 
                 self.metrics_client.publish_single_metric(
-                    metric_name="ingested_item",
-                    value=1,
-                    unit="Count",
-                    metric_dimensions=self.metrics_dimensions,
+                    Metric(
+                        name="ingested_item",
+                        value=1,
+                        unit="Count",
+                        dimensions=self.metrics_dimensions,
+                    )
                 )
             elif result_message.result_type == "error":
                 item_submission.status = ItemSubmissionStatus.INGEST_FAILED
@@ -453,10 +459,12 @@ class Workflow(ABC):
                 logger.debug(f"Record {log_str} failed to ingest")
 
                 self.metrics_client.publish_single_metric(
-                    metric_name="ingest_error",
-                    value=1,
-                    unit="Count",
-                    metric_dimensions=self.metrics_dimensions,
+                    Metric(
+                        name="ingest_error",
+                        value=1,
+                        unit="Count",
+                        dimensions=self.metrics_dimensions,
+                    )
                 )
 
             else:

--- a/dsc/workflows/base/workflow.py
+++ b/dsc/workflows/base/workflow.py
@@ -335,20 +335,7 @@ class Workflow(ABC):
                 item_submission.status_details = None
                 item_submission.submit_attempts += 1
                 item_submission.upsert_db()
-                try:
-                    self.metrics_client.publish_metric(
-                        Metric(
-                            name="item_submitted",
-                            value=1,
-                            unit="Count",
-                            dimensions=self.metrics_dimensions,
-                        )
-                    )
-                except Exception:
-                    logger.exception(
-                        f"Failed to publish item submitted metric for item "
-                        f"{item_identifier}"
-                    )
+                self._publish_count_metric("item_submitted", f"item {item_identifier}")
             except NotImplementedError:
                 raise
             except Exception as exception:  # noqa: BLE001
@@ -357,20 +344,9 @@ class Workflow(ABC):
                 item_submission.status_details = str(exception)
                 item_submission.submit_attempts += 1
                 item_submission.upsert_db()
-                try:
-                    self.metrics_client.publish_metric(
-                        Metric(
-                            name="submission_error",
-                            value=1,
-                            unit="Count",
-                            dimensions=self.metrics_dimensions,
-                        )
-                    )
-                except Exception:
-                    logger.exception(
-                        f"Failed to publish submission error metric for item "
-                        f"{item_submission.item_identifier}"
-                    )
+                self._publish_count_metric(
+                    "submission_error", f"item {item_submission.item_identifier}"
+                )
 
         logger.info(
             f"Submitted messages to the DSS input queue '{CONFIG.sqs_queue_dss_input}' "
@@ -456,37 +432,13 @@ class Workflow(ABC):
                 )
                 sqs_results_summary["ingest_success"] += 1
                 logger.debug(f"Record {log_str} was ingested")
-                try:
-                    self.metrics_client.publish_metric(
-                        Metric(
-                            name="ingested_item",
-                            value=1,
-                            unit="Count",
-                            dimensions=self.metrics_dimensions,
-                        )
-                    )
-                except Exception:
-                    logger.exception(
-                        f"Failed to publish ingested item metric for record {log_str}"
-                    )
+                self._publish_count_metric("ingested_item", f"record {log_str}")
             elif result_message.result_type == "error":
                 item_submission.status = ItemSubmissionStatus.INGEST_FAILED
                 item_submission.status_details = result_message.error_info
                 sqs_results_summary["ingest_failed"] += 1
                 logger.debug(f"Record {log_str} failed to ingest")
-                try:
-                    self.metrics_client.publish_metric(
-                        Metric(
-                            name="ingest_error",
-                            value=1,
-                            unit="Count",
-                            dimensions=self.metrics_dimensions,
-                        )
-                    )
-                except Exception:
-                    logger.exception(
-                        f"Failed to publish ingest error metric for record {log_str}"
-                    )
+                self._publish_count_metric("ingest_error", f"record {log_str}")
 
             else:
                 item_submission.status = ItemSubmissionStatus.INGEST_UNKNOWN
@@ -512,6 +464,27 @@ class Workflow(ABC):
         logger.info(
             f"No extra processing for batch based on workflow: '{self.workflow_name}' "
         )
+
+    def _publish_count_metric(self, metric_name: str, log_data: str) -> None:
+        """Publish a count metric to CloudWatch.
+
+        Any exceptions are caught and logged.
+
+        Args:
+            metric_name: The name of the metric to publish.
+            log_data: Additional data included in the log message.
+        """
+        try:
+            self.metrics_client.publish_metric(
+                Metric(
+                    name=metric_name,
+                    value=1,
+                    unit="Count",
+                    dimensions=self.metrics_dimensions,
+                )
+            )
+        except Exception:
+            logger.exception(f"Failed to publish '{metric_name}' metric: {log_data}")
 
     def send_report(
         self,

--- a/dsc/workflows/base/workflow.py
+++ b/dsc/workflows/base/workflow.py
@@ -335,15 +335,20 @@ class Workflow(ABC):
                 item_submission.status_details = None
                 item_submission.submit_attempts += 1
                 item_submission.upsert_db()
-
-                self.metrics_client.publish_metric(
-                    Metric(
-                        name="item_submitted",
-                        value=1,
-                        unit="Count",
-                        dimensions=self.metrics_dimensions,
+                try:
+                    self.metrics_client.publish_metric(
+                        Metric(
+                            name="item_submitted",
+                            value=1,
+                            unit="Count",
+                            dimensions=self.metrics_dimensions,
+                        )
                     )
-                )
+                except Exception:
+                    logger.exception(
+                        f"Failed to publish item submitted metric for item "
+                        f"{item_identifier}"
+                    )
             except NotImplementedError:
                 raise
             except Exception as exception:  # noqa: BLE001
@@ -352,15 +357,20 @@ class Workflow(ABC):
                 item_submission.status_details = str(exception)
                 item_submission.submit_attempts += 1
                 item_submission.upsert_db()
-
-                self.metrics_client.publish_metric(
-                    Metric(
-                        name="submission_error",
-                        value=1,
-                        unit="Count",
-                        dimensions=self.metrics_dimensions,
+                try:
+                    self.metrics_client.publish_metric(
+                        Metric(
+                            name="submission_error",
+                            value=1,
+                            unit="Count",
+                            dimensions=self.metrics_dimensions,
+                        )
                     )
-                )
+                except Exception:
+                    logger.exception(
+                        f"Failed to publish submission error metric for item "
+                        f"{item_submission.item_identifier}"
+                    )
 
         logger.info(
             f"Submitted messages to the DSS input queue '{CONFIG.sqs_queue_dss_input}' "
@@ -446,29 +456,37 @@ class Workflow(ABC):
                 )
                 sqs_results_summary["ingest_success"] += 1
                 logger.debug(f"Record {log_str} was ingested")
-
-                self.metrics_client.publish_metric(
-                    Metric(
-                        name="ingested_item",
-                        value=1,
-                        unit="Count",
-                        dimensions=self.metrics_dimensions,
+                try:
+                    self.metrics_client.publish_metric(
+                        Metric(
+                            name="ingested_item",
+                            value=1,
+                            unit="Count",
+                            dimensions=self.metrics_dimensions,
+                        )
                     )
-                )
+                except Exception:
+                    logger.exception(
+                        f"Failed to publish ingested item metric for record {log_str}"
+                    )
             elif result_message.result_type == "error":
                 item_submission.status = ItemSubmissionStatus.INGEST_FAILED
                 item_submission.status_details = result_message.error_info
                 sqs_results_summary["ingest_failed"] += 1
                 logger.debug(f"Record {log_str} failed to ingest")
-
-                self.metrics_client.publish_metric(
-                    Metric(
-                        name="ingest_error",
-                        value=1,
-                        unit="Count",
-                        dimensions=self.metrics_dimensions,
+                try:
+                    self.metrics_client.publish_metric(
+                        Metric(
+                            name="ingest_error",
+                            value=1,
+                            unit="Count",
+                            dimensions=self.metrics_dimensions,
+                        )
                     )
-                )
+                except Exception:
+                    logger.exception(
+                        f"Failed to publish ingest error metric for record {log_str}"
+                    )
 
             else:
                 item_submission.status = ItemSubmissionStatus.INGEST_UNKNOWN

--- a/dsc/workflows/base/workflow.py
+++ b/dsc/workflows/base/workflow.py
@@ -19,7 +19,7 @@ from dsc.exceptions import (
 )
 from dsc.item_submission import ItemSubmission
 from dsc.reports import CreateReport, FinalizeReport, SubmitReport
-from dsc.utils.aws import SESClient, SQSClient
+from dsc.utils.aws import MetricsClient, SESClient, SQSClient
 from dsc.utils.validate.schemas import RESULT_MESSAGE_ATTRIBUTES, RESULT_MESSAGE_BODY
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -129,6 +129,11 @@ class Workflow(ABC):
             "submitted": 0,
             "skipped": 0,
             "errors": 0,
+        }
+        self.metrics_client = MetricsClient()
+        self.metrics_dimensions = {
+            "application": "dsc",
+            "workflow_name": self.workflow_name,
         }
 
         # cache list of bitstreams
@@ -328,6 +333,12 @@ class Workflow(ABC):
                 item_submission.status_details = None
                 item_submission.submit_attempts += 1
                 item_submission.upsert_db()
+                self.metrics_client.publish_single_metric(
+                    metric_name="item_submitted",
+                    value=1,
+                    unit="Count",
+                    metric_dimensions=self.metrics_dimensions,
+                )
             except NotImplementedError:
                 raise
             except Exception as exception:  # noqa: BLE001
@@ -336,6 +347,13 @@ class Workflow(ABC):
                 item_submission.status_details = str(exception)
                 item_submission.submit_attempts += 1
                 item_submission.upsert_db()
+
+                self.metrics_client.publish_single_metric(
+                    metric_name="submission_error",
+                    value=1,
+                    unit="Count",
+                    metric_dimensions=self.metrics_dimensions,
+                )
 
         logger.info(
             f"Submitted messages to the DSS input queue '{CONFIG.sqs_queue_dss_input}' "
@@ -421,11 +439,26 @@ class Workflow(ABC):
                 )
                 sqs_results_summary["ingest_success"] += 1
                 logger.debug(f"Record {log_str} was ingested")
+
+                self.metrics_client.publish_single_metric(
+                    metric_name="ingested_item",
+                    value=1,
+                    unit="Count",
+                    metric_dimensions=self.metrics_dimensions,
+                )
             elif result_message.result_type == "error":
                 item_submission.status = ItemSubmissionStatus.INGEST_FAILED
                 item_submission.status_details = result_message.error_info
                 sqs_results_summary["ingest_failed"] += 1
                 logger.debug(f"Record {log_str} failed to ingest")
+
+                self.metrics_client.publish_single_metric(
+                    metric_name="ingest_error",
+                    value=1,
+                    unit="Count",
+                    metric_dimensions=self.metrics_dimensions,
+                )
+
             else:
                 item_submission.status = ItemSubmissionStatus.INGEST_UNKNOWN
                 sqs_results_summary["ingest_unknown"] += 1

--- a/dsc/workflows/base/workflow.py
+++ b/dsc/workflows/base/workflow.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, final
 import jsonschema
 import jsonschema.exceptions
 
-from dsc.config import ALLOWED_METRICS, Config
+from dsc.config import ALLOWED_METRICS, METRICS_NAMESPACE, Config
 from dsc.db.models import ItemSubmissionStatus
 from dsc.exceptions import (
     BatchCreationFailedError,
@@ -130,7 +130,9 @@ class Workflow(ABC):
             "skipped": 0,
             "errors": 0,
         }
-        self.metrics_client = MetricsClient(allowed_metrics=ALLOWED_METRICS)
+        self.metrics_client = MetricsClient(
+            namespace=METRICS_NAMESPACE, allowed_metrics=ALLOWED_METRICS
+        )
         self.metrics_dimensions = {
             "application": "dsc",
             "workflow_name": self.workflow_name,
@@ -333,7 +335,8 @@ class Workflow(ABC):
                 item_submission.status_details = None
                 item_submission.submit_attempts += 1
                 item_submission.upsert_db()
-                self.metrics_client.publish_single_metric(
+
+                self.metrics_client.publish_metric(
                     Metric(
                         name="item_submitted",
                         value=1,
@@ -350,7 +353,7 @@ class Workflow(ABC):
                 item_submission.submit_attempts += 1
                 item_submission.upsert_db()
 
-                self.metrics_client.publish_single_metric(
+                self.metrics_client.publish_metric(
                     Metric(
                         name="submission_error",
                         value=1,
@@ -444,7 +447,7 @@ class Workflow(ABC):
                 sqs_results_summary["ingest_success"] += 1
                 logger.debug(f"Record {log_str} was ingested")
 
-                self.metrics_client.publish_single_metric(
+                self.metrics_client.publish_metric(
                     Metric(
                         name="ingested_item",
                         value=1,
@@ -458,7 +461,7 @@ class Workflow(ABC):
                 sqs_results_summary["ingest_failed"] += 1
                 logger.debug(f"Record {log_str} failed to ingest")
 
-                self.metrics_client.publish_single_metric(
+                self.metrics_client.publish_metric(
                     Metric(
                         name="ingest_error",
                         value=1,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "lxml>=6.0.2",
     "pandas>=2.3.3",
     "pynamodb>=6.1.0",
-    "requests>=2.33.0",
+    "requests>=2.34.0",
     "sentry-sdk>=2.50.0",
     "smart_open",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -588,7 +588,7 @@ requires-dist = [
     { name = "lxml", specifier = ">=6.0.2" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "pynamodb", specifier = ">=6.1.0" },
-    { name = "requests", specifier = ">=2.33.0" },
+    { name = "requests", specifier = ">=2.34.0" },
     { name = "sentry-sdk", specifier = ">=2.50.0" },
     { name = "smart-open" },
 ]


### PR DESCRIPTION
### Purpose and background context
This PR creates a `MetricsClient` class that will eventually be added to our template repos and provides an opportunity to refine our conventions for publishing AWS metrics. 

### How can a reviewer manually see the effects of these changes?
This is not easily to manually test but you can review this [Cloudwatch query](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2?graph=~(metrics~(~(~'dso~'ingest_error~'application~'dsc~'workflow_name~'sccs~(id~'m1))~(~'.~'item_submitted~'.~'.~'.~'.~(id~'m2))~(~'.~'ingested_item~'.~'.~'.~'.~(id~'m3)))~sparkline~false~view~'timeSeries~stacked~false~region~'us-east-1~stat~'Sum~period~3600~start~'-PT168H~end~'P0D)&query=~'*7bdso*2capplication*2cworkflow_name*7d) to see the metrics that have been produced by this code over the past week

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- NA

### Code review
* Code review best practices are documented [here](https://mitlibraries.github.io/guides/collaboration/code_review.html) and you are encouraged to have a constructive dialogue with your reviewers about their preferences and expectations.