### PR TITLE
In 1626 digitized theses workflow create

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,6 @@ repos:
         types: ["python"]
       - id: pip-audit
         name: pip-audit
-        entry: uv run pip-audit
+        entry: uv run pip-audit --ignore-vuln PYSEC-2024-271
         language: system
         pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ ruff: # Run 'ruff' linter and print a preview of errors
 	uv run ruff check .
 
 safety: # Check for security vulnerabilities and verify Pipfile.lock is up-to-date
-	uv run pip-audit
+	uv run pip-audit --ignore-vuln PYSEC-2024-271
 
 lint-apply: black-apply ruff-apply # Apply changes with 'black' and resolve 'fixable errors' with 'ruff'
 

--- a/dsc/config.py
+++ b/dsc/config.py
@@ -15,6 +15,10 @@ class Config:
         "S3_BUCKET_SUBMISSION_ASSETS",
         "SOURCE_EMAIL",
         "SQS_QUEUE_DSS_INPUT",
+        # workflow-specific
+        "DSPACE_CREDENTIALS",
+        "METADATA_API_URL",
+        "S3_BUCKET_DIGITIZED_THESES",
     ]
 
     OPTIONAL_ENV_VARS: Iterable[str] = [
@@ -76,6 +80,28 @@ class Config:
         if _excluded_loggers := os.getenv("WARNING_ONLY_LOGGERS"):
             return _excluded_loggers.split(",")
         return []
+
+    # Workflow-specific env vars
+    @property
+    def dspace_credentials(self) -> str:
+        value = os.getenv("DSPACE_CREDENTIALS")
+        if not value:
+            raise OSError("Env var 'DSPACE_CREDENTIALS' must be defined")
+        return value
+
+    @property
+    def metadata_api_url(self) -> str:
+        value = os.getenv("METADATA_API_URL")
+        if not value:
+            raise OSError("Env var 'METADATA_API_URL' must be defined")
+        return value
+
+    @property
+    def s3_bucket_digitized_theses(self) -> str:
+        value = os.getenv("S3_BUCKET_DIGITIZED_THESES")
+        if not value:
+            raise OSError("Env var 'S3_BUCKET_DIGITIZED_THESES' must be defined")
+        return value
 
     def check_required_env_vars(self) -> None:
         """Method to raise exception if required env vars not set."""

--- a/dsc/config.py
+++ b/dsc/config.py
@@ -83,11 +83,13 @@ class Config:
 
     # Workflow-specific env vars
     @property
-    def dspace_credentials(self) -> str:
+    def dspace_credentials(self) -> dict:
         value = os.getenv("DSPACE_CREDENTIALS")
         if not value:
             raise OSError("Env var 'DSPACE_CREDENTIALS' must be defined")
-        return value
+        credentials = json.loads(value)
+
+        return {"IR-8": credentials["ir-8"], "DDC-8": credentials["ddc-8"]}
 
     @property
     def metadata_api_url(self) -> str:

--- a/dsc/db/models.py
+++ b/dsc/db/models.py
@@ -21,6 +21,9 @@ ITEM_SUBMISSION_LOG_STR = (
 
 
 class ItemSubmissionStatus(StrEnum):
+    CREATE_SUCCESS = "create_success"
+    CREATE_FAILED = "create_failed"
+    CREATE_SKIPPED = "create_skipped"
     BATCH_CREATED = "batch_created"
     SUBMIT_SUCCESS = "submit_success"
     SUBMIT_FAILED = "submit_failed"

--- a/dsc/exceptions.py
+++ b/dsc/exceptions.py
@@ -30,6 +30,43 @@ class SQSMessageSendError(Exception):
     pass
 
 
+# Exceptions for DSpace client
+class DSpaceClientError(Exception):
+    """General exception raised when DSpace client action results in error."""
+
+
+class DSpaceClientCredentialsNotFoundError(DSpaceClientError):
+    """Raise when env var DSPACE_CREDENTIALS does not include submission system."""
+
+
+class DSpaceClientAuthenticationError(DSpaceClientError):
+    """Raise when DSpace client fails authentication.
+
+    Authentication may fail due to 401 Unauthorized or 403 Forbidden errors.
+    """
+
+    def __init__(
+        self,
+        dspace_url: str | float | None,
+        dspace_user: str | float | None,
+    ):
+        self.message = (
+            f"Failed to authenticate to DSpace server at '{dspace_url}' with user "
+            f"'{dspace_user}'. Please verify that the DSPACE_CREDENTIALS "
+            "environment variable is set correctly and that the DSpace server is "
+            "accessible."
+        )
+
+
+class DSpaceClientSearchError(DSpaceClientError):
+    """Raise when DSpace client search operation results in error.
+
+    Search is performed by dspace_rest_client.client.search_objects,
+    which returns None if the response from a GET request returns an
+    exit code other than 200.
+    """
+
+
 # Exceptions for 'create-batch' step
 class BatchCreationFailedError(Exception):
     def __init__(self, errors: list[tuple]) -> None:

--- a/dsc/workflows/digitized_theses/__init__.py
+++ b/dsc/workflows/digitized_theses/__init__.py
@@ -1,3 +1,4 @@
-from dsc.workflows.digitized_theses.transformer import DigitizedThesesTransformer, NSMAP
+from dsc.workflows.digitized_theses.transformer import NSMAP, DigitizedThesesTransformer
+from dsc.workflows.digitized_theses.workflow import DigitizedTheses
 
-__all__ = ["DigitizedThesesTransformer", "NSMAP"]
+__all__ = ["NSMAP", "DigitizedTheses", "DigitizedThesesTransformer"]

--- a/dsc/workflows/digitized_theses/__init__.py
+++ b/dsc/workflows/digitized_theses/__init__.py
@@ -1,3 +1,3 @@
-from dsc.workflows.digitized_theses.transformer import DigitizedThesesTransformer
+from dsc.workflows.digitized_theses.transformer import DigitizedThesesTransformer, NSMAP
 
-__all__ = ["DigitizedThesesTransformer"]
+__all__ = ["DigitizedThesesTransformer", "NSMAP"]

--- a/dsc/workflows/digitized_theses/transformer.py
+++ b/dsc/workflows/digitized_theses/transformer.py
@@ -11,7 +11,7 @@ from lxml import etree
 
 from dsc.config import load_external_config
 
-NSMAP = {"marc": "http://www.loc.gov/MARC21/slim"}
+NSMAP = {"marc": "http://www.loc.gov/MARC21/slim", "sru": "http://www.loc.gov/zing/srw/"}
 
 
 class DigitizedThesesTransformer:

--- a/dsc/workflows/digitized_theses/workflow.py
+++ b/dsc/workflows/digitized_theses/workflow.py
@@ -1,0 +1,459 @@
+# ruff: noqa: FIX002, TD002, TD003
+import glob
+import logging
+import os
+import re
+import shutil
+import tempfile
+from collections.abc import Iterator
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+import requests
+from dspace_rest_client.client import DSpaceClient
+from dspace_rest_client.models import Item as DSpaceItem
+from lxml import etree
+
+from dsc import exceptions
+from dsc.config import Config
+from dsc.db.models import ItemSubmissionStatus
+from dsc.item_submission import ItemSubmission
+from dsc.utils.aws.s3 import S3Client, run_aws_cli_sync
+from dsc.workflows.base import Workflow
+from dsc.workflows.digitized_theses import NSMAP, DigitizedThesesTransformer
+
+CONFIG = Config()
+logger = logging.getLogger(__name__)
+
+
+class MITThesesCommunityUUID(StrEnum):
+    DEV = ""  # TODO: Update to uuid for 'MIT Theses' community in test
+    PROD = "6fc02cc2-0d14-4023-8a6f-d9900d0c4302"
+
+
+class DigitizedTheses(Workflow):
+    """Workflow for digitized theses from the Imaging Lab.
+
+    This workflow is unique to other workflows in that it relies on an
+    additional S3 bucket that serves as a "workspace" for digitized theses.
+    Users create a batch folder in this workspace S3 bucket and upload
+    theses (PDF files) named with the OCLC number: <oclc-number>-MIT.pdf.
+
+    When this workflow creates a batch *without* syncing, it will first
+    copy the contents of the original batch folder in the workspace S3 bucket
+    to a dated batch folder in a temporary directory on local disk.
+    The batch folder will organize item submission assets into subfolders
+    based on whether it is a new or replacement thesis or whether it should
+    be skipped. Once the contents of the local batch are ready, it is
+    synced to a similarly named batch folder in the DSC S3 bucket and
+    ItemSubmission's are recorded in DynamoDB.
+
+    When this workflow creates a batch *with* syncing, this means an organized
+    batch folder already exists in the DSC S3 bucket in Prod, which is the
+    result of syncing data from Stage. This method will instead walk
+    the contents of the synced batch folder to create ItemSubmission's
+    that are recorded in DynamoDB.
+
+    TODO: Add description for `submit` and `finalize` methods.
+    """
+
+    workflow_name: str = "digitized-theses"
+    metadata_transformer = DigitizedThesesTransformer
+
+    def __init__(self, batch_id: str):
+        self._dspace_client = None
+        self.community_uuid = (
+            MITThesesCommunityUUID.PROD
+            if CONFIG.workspace == "prod"
+            else MITThesesCommunityUUID.DEV
+        )
+        super().__init__(batch_id)
+
+    @property
+    def metadata_mapping_path(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def dspace_client(self) -> DSpaceClient:
+        if not self._dspace_client:
+            logger.debug(
+                f"Creating DSpace client for destination {self.submission_system}"
+            )
+
+            try:
+                credentials = CONFIG.dspace_credentials[self.submission_system]
+            except KeyError as exception:
+                raise exceptions.DSpaceClientCredentialsNotFoundError(
+                    f"No credentials for {self.submission_system}"
+                ) from exception
+
+            client = DSpaceClient(
+                api_endpoint=credentials["url"],
+                username=credentials["user"],
+                password=credentials["password"],
+                fake_user_agent=True,
+            )
+            authenticated = client.authenticate()
+            if not authenticated:
+                raise exceptions.DSpaceClientAuthenticationError(
+                    credentials["url"], credentials["user"]
+                )
+            self._dspace_client = client
+            logger.info(
+                f"Successfully authenticated to {credentials['url']} "
+                f"as {credentials['url']}"
+            )
+
+        return self._dspace_client
+
+    def get_batch_bitstream_uris(self) -> list[str]:
+        raise NotImplementedError
+
+    def item_metadata_iter(self) -> Iterator[dict[str, Any]]:
+        raise NotImplementedError
+
+    def prepare_batch(self, *, synced: bool = False) -> tuple[list, ...]:
+        """Prepare a batch folder in the DSC S3 bucket.
+
+        Unlike other workflows, successes, failures, and skips are recorded in the
+        item submissions table in DynamoDB, as a means to collate all results for a batch
+        in the batch creation report. This means, the method will always return an empty
+        'errors' list.
+        """
+        item_submissions = []
+        errors: list[tuple] = []  # set but not used
+
+        if synced:
+            logger.info(f"Batch folder already created in WORKSPACE={CONFIG.workspace}")
+            item_submissions = self._get_item_submissions_from_synced_batch()
+        else:
+            item_submissions = self._create_batch_in_s3()
+
+        return item_submissions, errors
+
+    def _get_item_submissions_from_synced_batch(self) -> list[ItemSubmission]:
+        """Create ItemSubmission's from a synced batch folder in the DSC S3 bucket.
+
+        This method loops through the uris for objects in the synced batch folder.
+        From each uri, the method extracts the theses subfolder and the item identifier
+        for an item submission. The theses subfolder determines the ItemSubmission.status
+        to set in DynamoDB:
+            - Item submissions in replacement-theses or new-theses -> CREATE_SUCCESS
+            - Item submissions in skipped-theses -> CREATE_SKIPPED
+
+        As the method loops through the uris, it checks against a list of seen
+        item identifiers to avoid duplicates.
+        """
+        item_submissions = []
+        s3_client = S3Client()
+
+        # pattern to extract meta about item submission from uri
+        pattern = r"/(?:[^/]+/)*?([a-zA-Z0-9-]*-theses)/(\d+)(?:/.*)?$"
+
+        seen_item_identifiers = []
+        for uri in s3_client.files_iter(bucket=self.s3_bucket, prefix=self.batch_path):
+            match = re.search(pattern, uri)
+            if not match:
+                logger.warning(f"Cannot create item submission for uri: {uri}")
+                continue
+
+            # retrieve theses subfolder and item identifier from uri
+            theses_subfolder, item_identifier = match.groups()
+            if item_identifier in seen_item_identifiers:
+                logger.debug(
+                    f"Already created an item submission for item_identifier={item_identifier}"  # noqa: E501
+                )
+                continue
+
+            seen_item_identifiers.append(item_identifier)
+            item_submissions.append(
+                ItemSubmission(
+                    batch_id=self.batch_id,
+                    item_identifier=item_identifier,
+                    workflow_name=self.workflow_name,
+                    status=(
+                        ItemSubmissionStatus.CREATE_SUCCESS
+                        if theses_subfolder in ["replacement-theses", "new-theses"]
+                        else ItemSubmissionStatus.CREATE_SKIPPED
+                    ),
+                )
+            )
+
+        return item_submissions
+
+    def _create_batch_in_s3(self) -> list[ItemSubmission]:
+        """Create a batch of item submissions in the DSC S3 bucket.
+
+        This method begins with syncing the contents of the original batch folder
+        in the digitized-theses-workspace S3 bucket to a dated batch folder in
+        a temporary directory on local disk. From there, it performs the following
+        steps for each thesis:
+
+        1. Download the MARC XML record from Alma and save to an XML file
+        2. Check if an item in DSpace already exists:
+            - If it exists and it is a student-submitted electronic thesis, skip
+            - If it exists and is not, mark as 'Replacement thesis'
+            - If it does not exist, mark as 'New thesis'
+        3. Organize the contents of the dated batch folder by thesis type
+        4. Sync the dated batch folder to the workflow folder in the DSC S3 bucket
+        5. Clean up the temporary directory
+        """
+        item_submissions = []
+
+        # update self.batch_id to include current date timestamp
+        original_batch_id = self.batch_id
+        self.batch_id = self._update_batch_id(original_batch_id)
+
+        # create temp directory
+        tmp_dir = tempfile.TemporaryDirectory()
+        logger.info(f"Created temporary directory: {tmp_dir.name}")
+
+        # sync batch folder from digitized-theses-workspace S3 bucket
+        # to dated batch folder in temp directory
+        tmp_batch_path = f"{tmp_dir.name}/{self.batch_id}"
+        run_aws_cli_sync(
+            source=f"s3://{CONFIG.s3_bucket_digitized_theses}/{original_batch_id}",
+            destination=tmp_batch_path,
+        )
+
+        for file in os.listdir(tmp_batch_path):
+            item_submission = ItemSubmission(
+                batch_id=self.batch_id,
+                item_identifier=self.parse_item_identifier(file),
+                workflow_name=self.workflow_name,
+            )
+
+            # get MARC XML metadata from Alma
+            try:
+                self._download_metadata_from_alma(
+                    item_submission, batch_location=tmp_batch_path
+                )
+            except (
+                requests.exceptions.HTTPError,
+                exceptions.ItemMetadataNotFoundError,
+            ) as exception:
+                item_submission.status = "create_failed"
+                item_submission.status_details = str(exception)
+                item_submissions.append(item_submission)
+                continue
+
+            # check if item with the OCLC number exists
+            try:
+                dspace_item = self._get_item_from_dspace(item_submission.item_identifier)
+            except exceptions.DSpaceClientSearchError as exception:
+                item_submission.status = "create_skipped"
+                item_submission.status_details = str(exception)
+                item_submissions.append(item_submission)
+                continue
+
+            # check if item submission is a 'Replacement thesis'
+            if dspace_item and not self._is_replacement_thesis(dspace_item):
+                item_submission.status = "create_skipped"
+                item_submission.status_details = "Cannot replace the electronic version submitted by the student author."  # noqa: E501
+                item_submissions.append(item_submission)
+                continue
+
+            if dspace_item and self._is_replacement_thesis(dspace_item):
+                item_submission.status = "create_success"
+                item_submission.status_details = "Replacement thesis"
+                item_submissions.append(item_submission)
+            else:
+                item_submission.status = "create_success"
+                item_submission.status_details = "New thesis"
+                item_submissions.append(item_submission)
+
+        self._move_batch_files_to_theses_subfolders(
+            item_submissions, batch_location=tmp_batch_path
+        )
+
+        # sync batch folder from digitized-theses-workspace S3 bucket
+        # to dated batch folder in temporary directory
+        run_aws_cli_sync(
+            source=tmp_batch_path,
+            destination=f"s3://{CONFIG.s3_bucket_submission_assets}/{self.batch_path}",
+        )
+
+        # clean up temp directory
+        tmp_dir.cleanup()
+
+        return item_submissions
+
+    def _update_batch_id(self, batch_id: str) -> str:
+        """Create a new batch ID with a date timestamp.
+
+        This method is only used when creating a batch *without syncing*.
+        The updated batch ID is used to distinguish different runs of
+        Workflow.create_batch, which can be run as many times as needed
+        until a batch is ready for submission.
+        """
+        return f"{batch_id}-{self.run_date.strftime('%Y%m%dT%H%M%SZ')}"
+
+    def _download_metadata_from_alma(
+        self, item_submission: ItemSubmission, batch_location: str
+    ) -> bytes:
+        """Download MARC XML metadata for an item submission from Alma.
+
+        This method writes an XML file with MARC metadata to the
+        batch folder in S3 named: '<oclc-number>-MIT.xml'
+
+        For more information, see:
+        https://developers.exlibrisgroup.com/alma/integrations/sru/.
+        """
+        logger.debug(
+            f"Retrieving metadata from Alma for an item with alma.oclc_control_number_035_a={item_submission.item_identifier}"  # noqa: E501
+        )
+
+        query_url = f"https://{CONFIG.metadata_api_url}"
+        response = requests.get(
+            query_url,
+            params={
+                "operation": "searchRetrieve",
+                "recordSchema": "marcxml",
+                "query": (
+                    f"alma.oclc_control_number_035_a={item_submission.item_identifier}"
+                ),
+            },
+            timeout=180,
+        )
+
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as exception:
+            # TODO: Custom error includes HTTPError message
+            raise exceptions.ItemMetadataNotFoundError from exception
+
+        # get nested `<marc:record>` element from SRU response
+        record_element = self._parse_record_from_sru_response(response.content)
+
+        # write an XML file to batch folder
+        with open(
+            Path(batch_location) / f"{item_submission.item_identifier}.xml", "wb"
+        ) as file:
+            tree = etree.ElementTree(record_element)
+            tree.write(file, xml_declaration=True, encoding="UTF-8")
+
+        return response.content
+
+    def _get_item_from_dspace(self, item_identifier: str) -> DSpaceItem:
+        """Get Item object from DSpace given an item identifier.
+
+        This method expects only a single Item object for a given item identifier
+        (if any). If DSpaceClient.search_objects returns None or a list of more than
+        one Item objects, this method raises exceptions.DSpaceClientSearchError.
+        """
+        logger.debug(
+            f"Searching DSpace for an item with dc.identifier.oclc={item_identifier}"
+        )
+
+        dspace_objects = self.dspace_client.search_objects(
+            query=f"dc.identifier.oclc:{item_identifier}",
+            scope=self.community_uuid,
+            dso_type="item",
+        )
+
+        if dspace_objects is None:
+            raise exceptions.DSpaceClientSearchError(
+                f"Failed search for item with dc.identifier.oclc={item_identifier} "
+                f"in community {"<community>"}"
+            )
+        if len(dspace_objects) > 1:
+            raise exceptions.DSpaceClientSearchError(
+                f"Expecting one item with dc.identifier.oclc={item_identifier} "
+                f"in community {"<community>"}; found {len(dspace_objects)} items"
+            )
+        if len(dspace_objects) == 0:
+            return None
+
+        return dspace_objects[0]
+
+    def _move_batch_files_to_theses_subfolders(
+        self, item_submissions: list[ItemSubmission], batch_location: str
+    ) -> None:
+        """Move item submission assets in batch folder into theses subfolders.
+
+        This method will inspect the `status_details` for each item submission to
+        determine which theses subfolder (prefix) its content should be moved to.
+        At this point, `status_details` will contain "Replacement thesis",
+        "New thesis", or an exception message. If `status_details` contains an
+        exception message, contents are moved to a skipped-theses/ subfolder.
+
+        When contents for an item submission are moved to theses subfolders,
+        they are nested under a prefix named with the item identifier:
+
+            batch-0/replacement-theses/001/001.xml <-- Alma MARC metadata
+            batch-0/replacement-theses/001/001.pdf <-- digitized theses
+        """
+        for item_submission in item_submissions:
+            if item_submission.status_details == "Replacement thesis":
+                theses_prefix = "replacement-theses"
+            elif item_submission.status_details == "New thesis":
+                theses_prefix = "new-theses"
+            else:
+                theses_prefix = "skipped-theses"
+
+            # create item submission prefix under theses prefix
+            item_submission_location = (
+                Path(batch_location) / theses_prefix / item_submission.item_identifier
+            )
+            if not os.path.exists(item_submission_location):
+                os.makedirs(item_submission_location)
+
+            logger.debug(
+                "Moving files associated with item_identifier="
+                f"{item_submission.item_identifier} to '{item_submission_location}'"
+            )
+
+            # move item submission assets to their assigned subfolder
+            for file in glob.glob(f"{batch_location}/{item_submission.item_identifier}*"):
+                filename = file.rsplit("/", maxsplit=1)[-1]
+                shutil.move(file, f"{item_submission_location}/{filename}")
+
+    @staticmethod
+    def _is_replacement_thesis(item: DSpaceItem) -> bool:
+        """Determine if a DSpace item is a replacement thesis.
+
+        If an item is already present in DSpace, its thesis file (bitstream)
+        should be replaced only when it is not a student-submitted electronic PDF.
+        This determination is made by checking for a specific target string in
+        the dc.description field.
+
+        This method returns True if the target string is absent
+        from all dc.description entries (if any exist), indicating that it is
+        safe to proceed with the replacement.
+        """
+        # skip the record if any dc_description value matches this string
+        target_string = "This electronic version was submitted by the student author."
+
+        if item.metadata.get("dc.description"):
+            dc_description_values = [
+                entry.get("value", "") for entry in item.metadata["dc.description"]
+            ]
+
+            if target_string in "|".join(dc_description_values):
+                return False
+
+        return True
+
+    @staticmethod
+    def _parse_record_from_sru_response(content: bytes) -> etree._Element:
+        root = etree.fromstring(content)
+        number_of_records = root.find("sru:numberOfRecords", namespaces=NSMAP)
+
+        if number_of_records is None:
+            # TODO: Custom error includes message "Unexpected response from Alma SRU"
+            raise exceptions.ItemMetadataNotFoundError
+
+        if int(number_of_records.text) == 0:
+            raise exceptions.ItemMetadataNotFoundError
+
+        if int(number_of_records.text) > 1:
+            # TODO: Custom error includes message
+            # "Unexpected response from Alma SRU, multiple records with OCLC"
+            raise exceptions.ItemMetadataNotFoundError
+
+        return root.xpath("//marc:record", namespaces=NSMAP)[0]
+
+    @staticmethod
+    def parse_item_identifier(filename: str) -> str:
+        return filename.rsplit("/", maxsplit=1)[-1].removesuffix("-MIT.pdf")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "boto3>=1.42.30",
     "boto3-stubs[essential, ses]>=1.42.30",
     "click>=8.3.1",
+    "dspace-rest-client>=0.1.17",
     "jinja2>=3.1.6",
     "jsonschema>=4.26.0",
     "lxml>=6.0.2",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,6 +135,13 @@ def _test_env(monkeypatch):
     monkeypatch.setenv("S3_BUCKET_SUBMISSION_ASSETS", "dsc")
     monkeypatch.setenv("SOURCE_EMAIL", "noreply@example.com")
     monkeypatch.setenv("SQS_QUEUE_DSS_INPUT", "mock-input-queue")
+    # workflow-specific
+    monkeypatch.setenv(
+        "DSPACE_CREDENTIALS",
+        '{"ir-8": {"url": "mock://mit-dspace.test.4science.cloud/server/api", "user": "user@test.com", "password": "topsecret"}, "ddc-8": {"url": "mock://dome.test.mitlibrary.net/rest", "user": "user@test.com", "password": "topsecret"}}',  # noqa: E501
+    )
+    monkeypatch.setenv("METADATA_API_URL", "mock.com/view/sru/01MIT_INST?version=1.2")
+    monkeypatch.setenv("S3_BUCKET_DIGITIZED_THESES", "digitized-theses-workspace-test")
 
 
 @pytest.fixture

--- a/tests/fixtures/digitized-theses/alma_sru_response_multiple_records.xml
+++ b/tests/fixtures/digitized-theses/alma_sru_response_multiple_records.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+    <version>
+        1.2
+    </version>
+    <numberOfRecords>
+        2
+    </numberOfRecords>
+    <records>
+    </records>
+    <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
+        <xb:exact>
+            true
+        </xb:exact>
+        <xb:responseDate>
+            2026-04-02T09:13:29-0400
+        </xb:responseDate>
+    </extraResponseData>
+</searchRetrieveResponse>

--- a/tests/fixtures/digitized-theses/alma_sru_response_no_record.xml
+++ b/tests/fixtures/digitized-theses/alma_sru_response_no_record.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+    <version>1.2</version>
+    <numberOfRecords>0</numberOfRecords>
+    <records />
+    <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
+        <xb:exact>true</xb:exact>
+        <xb:responseDate>2026-05-19T10:10:34-0400</xb:responseDate>
+    </extraResponseData>
+</searchRetrieveResponse>

--- a/tests/fixtures/digitized-theses/alma_sru_response_single_record.xml
+++ b/tests/fixtures/digitized-theses/alma_sru_response_single_record.xml
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="utf-8"?>
+<searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+    <version>
+        1.2
+    </version>
+    <numberOfRecords>
+        1
+    </numberOfRecords>
+    <records>
+        <record>
+            <recordSchema>
+                marcxml
+            </recordSchema>
+            <recordPacking>
+                xml
+            </recordPacking>
+            <recordData>
+                <record xmlns="http://www.loc.gov/MARC21/slim">
+                    <leader>
+                        00935ntm 2200301Ka 4500
+                    </leader>
+                    <controlfield tag="001">
+                        990008109770106761
+                    </controlfield>
+                    <controlfield tag="005">
+                        20241114051410.0
+                    </controlfield>
+                    <controlfield tag="008">
+                        970318s1929 xx a b 000 0 eng d
+                    </controlfield>
+                    <datafield ind1=" " ind2=" " tag="035">
+                        <subfield code="a">
+                            (MCM)000810977
+                        </subfield>
+                    </datafield>
+                    <datafield ind1=" " ind2=" " tag="035">
+                        <subfield code="a">
+                            (MCM)000810977MIT01
+                        </subfield>
+                    </datafield>
+                    <datafield ind1=" " ind2=" " tag="035">
+                        <subfield code="a">
+                            (OCoLC)36570527
+                        </subfield>
+                    </datafield>
+                    <datafield ind1=" " ind2=" " tag="040">
+                        <subfield code="a">
+                            MYG
+                        </subfield>
+                        <subfield code="c">
+                            MYG
+                        </subfield>
+                    </datafield>
+                    <datafield ind1=" " ind2=" " tag="049">
+                        <subfield code="a">
+                            MYGG
+                        </subfield>
+                    </datafield>
+                    <datafield ind1=" " ind2=" " tag="099">
+                        <subfield code="a">
+                            Thesis
+                        </subfield>
+                        <subfield code="a">
+                            Chem.Eng
+                        </subfield>
+                        <subfield code="a">
+                            1929
+                        </subfield>
+                        <subfield code="a">
+                            M.S.
+                        </subfield>
+                    </datafield>
+                    <datafield ind1="1" ind2=" " tag="100">
+                        <subfield code="a">
+                            Brown, Ernest K.
+                        </subfield>
+                    </datafield>
+                    <datafield ind1="1" ind2="4" tag="245">
+                        <subfield code="a">
+                            The crystallization of sucrose /
+                        </subfield>
+                        <subfield code="c">
+                            by Ernest K. Brown.
+                        </subfield>
+                    </datafield>
+                    <datafield ind1=" " ind2=" " tag="260">
+                        <subfield code="c">
+                            1929.
+                        </subfield>
+                    </datafield>
+                    <datafield ind1=" " ind2=" " tag="300">
+                        <subfield code="a">
+                            81, [7] leaves :
+                        </subfield>
+                        <subfield code="b">
+                            ill. ;
+                        </subfield>
+                        <subfield code="c">
+                            30 cm.
+                        </subfield>
+                    </datafield>
+                    <datafield ind1=" " ind2=" " tag="336">
+                        <subfield code="a">
+                            text
+                        </subfield>
+                        <subfield code="b">
+                            txt
+                        </subfield>
+                        <subfield code="2">
+                            rdacontent
+                        </subfield>
+                    </datafield>
+                    <datafield ind1=" " ind2=" " tag="337">
+                        <subfield code="a">
+                            unmediated
+                        </subfield>
+                        <subfield code="b">
+                            n
+                        </subfield>
+                        <subfield code="2">
+                            rdamedia
+                        </subfield>
+                    </datafield>
+                    <datafield ind1=" " ind2=" " tag="338">
+                        <subfield code="a">
+                            volume
+                        </subfield>
+                        <subfield code="b">
+                            nc
+                        </subfield>
+                        <subfield code="2">
+                            rdacarrier
+                        </subfield>
+                    </datafield>
+                    <datafield ind1=" " ind2=" " tag="502">
+                        <subfield code="b">
+                            M.S.
+                        </subfield>
+                        <subfield code="c">
+                            Massachusetts Institute of Technology, Department of Chemical Engineering
+                        </subfield>
+                        <subfield code="d">
+                            1929
+                        </subfield>
+                    </datafield>
+                    <datafield ind1=" " ind2=" " tag="504">
+                        <subfield code="a">
+                            Includes bibliographical references (leaf 81).
+                        </subfield>
+                    </datafield>
+                    <datafield ind1="4" ind2="0" tag="856">
+                        <subfield code="u">
+                            https://hdl.handle.net/1721.1/164695
+                        </subfield>
+                    </datafield>
+                    <datafield ind1=" " ind2=" " tag="910">
+                        <subfield code="a">
+                            metRECON
+                        </subfield>
+                    </datafield>
+                    <datafield ind1=" " ind2=" " tag="910">
+                        <subfield code="a">
+                            MARCIVEAUT
+                        </subfield>
+                    </datafield>
+                    <datafield ind1=" " ind2=" " tag="961">
+                        <subfield code="a">
+                            1929
+                        </subfield>
+                        <subfield code="a">
+                            xx
+                        </subfield>
+                    </datafield>
+                    <datafield ind1=" " ind2=" " tag="969">
+                        <subfield code="a">
+                            36570527
+                        </subfield>
+                    </datafield>
+                    <datafield ind1="0" ind2="0" tag="992">
+                        <subfield code="a">
+                            Supervised by W. K. Lewis.
+                        </subfield>
+                    </datafield>
+                    <datafield ind1=" " ind2=" " tag="AVA">
+                        <subfield code="0">
+                            990008109770106761
+                        </subfield>
+                        <subfield code="8">
+                            22500982500006761
+                        </subfield>
+                        <subfield code="a">
+                            01MIT_INST
+                        </subfield>
+                        <subfield code="b">
+                            ARC
+                        </subfield>
+                        <subfield code="c">
+                            Noncirculating Collection 3
+                        </subfield>
+                        <subfield code="d">
+                            THESIS Thesis Chem.Eng 1929 M.S.
+                        </subfield>
+                        <subfield code="e">
+                            available
+                        </subfield>
+                        <subfield code="f">
+                            1
+                        </subfield>
+                        <subfield code="g">
+                            0
+                        </subfield>
+                        <subfield code="j">
+                            NOLN3
+                        </subfield>
+                        <subfield code="k">
+                            8
+                        </subfield>
+                        <subfield code="p">
+                            1
+                        </subfield>
+                        <subfield code="q">
+                            Distinctive Collections
+                        </subfield>
+                    </datafield>
+                    <datafield ind1=" " ind2=" " tag="AVE">
+                        <subfield code="8">
+                            53739052910006761
+                        </subfield>
+                        <subfield code="c">
+                            61621075100006761
+                        </subfield>
+                        <subfield code="e">
+                            Available
+                        </subfield>
+                        <subfield code="m">
+                            MIT Theses in DSpace
+                        </subfield>
+                        <subfield code="a">
+                            01MIT_INST
+                        </subfield>
+                        <subfield code="0">
+                            990008109770106761
+                        </subfield>
+                    </datafield>
+                </record>
+            </recordData>
+            <recordIdentifier>
+                990008109770106761
+            </recordIdentifier>
+            <recordPosition>
+                1
+            </recordPosition>
+        </record>
+    </records>
+    <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
+        <xb:exact>
+            true
+        </xb:exact>
+        <xb:responseDate>
+            2026-04-02T09:13:29-0400
+        </xb:responseDate>
+    </extraResponseData>
+</searchRetrieveResponse>

--- a/tests/fixtures/digitized-theses/batch-aaa/replacement-theses/05588126.xml
+++ b/tests/fixtures/digitized-theses/batch-aaa/replacement-theses/05588126.xml
@@ -1,0 +1,135 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<record xmlns="http://www.loc.gov/MARC21/slim">
+          <leader>01243nam  2200397Ii 4500</leader>
+          <controlfield tag="001">990000762590106761</controlfield>
+          <controlfield tag="005">20241114182427.0</controlfield>
+          <controlfield tag="008">791025s1978    mau      b    000 0 eng d</controlfield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(MCM)000076259</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(MCM)000076259MIT01</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(OCoLC)05588126</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="040">
+            <subfield code="a">MYG</subfield>
+            <subfield code="c">MYG</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="049">
+            <subfield code="a">MYGT [Science]</subfield>
+            <subfield code="a">MYGS</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="099">
+            <subfield code="a">Thesis Math 1978 Ph.D.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="099">
+            <subfield code="a">Thesis</subfield>
+            <subfield code="a">Math</subfield>
+            <subfield code="a">1978</subfield>
+            <subfield code="a">Ph.D.</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="100">
+            <subfield code="a">Zhang, Weida.</subfield>
+          </datafield>
+          <datafield ind1="1" ind2="0" tag="245">
+            <subfield code="a">Global solvability of invariant differential operators.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="260">
+            <subfield code="c">c1978.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="300">
+            <subfield code="a">98 leaves ;</subfield>
+            <subfield code="c">28 cm.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="336">
+            <subfield code="a">text</subfield>
+            <subfield code="b">txt</subfield>
+            <subfield code="2">rdacontent</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="337">
+            <subfield code="a">unmediated</subfield>
+            <subfield code="b">n</subfield>
+            <subfield code="2">rdamedia</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="338">
+            <subfield code="a">volume</subfield>
+            <subfield code="b">nc</subfield>
+            <subfield code="2">rdacarrier</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="502">
+            <subfield code="b">Ph. D.</subfield>
+            <subfield code="c">Massachusetts Institute of Technology, Department of Mathematics</subfield>
+            <subfield code="d">1978</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="500">
+            <subfield code="a">Vita.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="504">
+            <subfield code="a">Bibliography: leaves 96-97.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="0" tag="650">
+            <subfield code="a">Partial differential operators.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="0" tag="650">
+            <subfield code="a">Lie groups.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="7" tag="650">
+            <subfield code="a">Lie groups.</subfield>
+            <subfield code="2">fast</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="7" tag="650">
+            <subfield code="a">Partial differential operators.</subfield>
+            <subfield code="2">fast</subfield>
+          </datafield>
+          <datafield ind1="4" ind2="0" tag="856">
+            <subfield code="u">https://hdl.handle.net/1721.1/157651</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="910">
+            <subfield code="a">JEH791025sw</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="910">
+            <subfield code="a">MARCIVEAUT</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="910">
+            <subfield code="a">MARCIVEAUT221103</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="961">
+            <subfield code="a">1978</subfield>
+            <subfield code="a">mau</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="969">
+            <subfield code="a">05588126</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="990">
+            <subfield code="a">MICROFICHE COPY AVAILABLE IN ARCHIVES AND SCIENCE.</subfield>
+          </datafield>
+          <datafield ind1="0" ind2="0" tag="992">
+            <subfield code="a">Supervised by Sigurdur Helgason.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="AVA">
+            <subfield code="0">990000762590106761</subfield>
+            <subfield code="8">22478285480006761</subfield>
+            <subfield code="a">01MIT_INST</subfield>
+            <subfield code="b">ARC</subfield>
+            <subfield code="c">Noncirculating Collection 3</subfield>
+            <subfield code="d">THESIS Thesis Math 1978 Ph.D.</subfield>
+            <subfield code="e">available</subfield>
+            <subfield code="f">1</subfield>
+            <subfield code="g">0</subfield>
+            <subfield code="j">NOLN3</subfield>
+            <subfield code="k">8</subfield>
+            <subfield code="p">1</subfield>
+            <subfield code="q">Distinctive Collections</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="AVE">
+            <subfield code="8">53709941790006761</subfield>
+            <subfield code="c">61621075100006761</subfield>
+            <subfield code="e">Available</subfield>
+            <subfield code="m">MIT Theses in DSpace</subfield>
+            <subfield code="a">01MIT_INST</subfield>
+            <subfield code="0">990000762590106761</subfield>
+          </datafield>
+        </record>
+      

--- a/tests/fixtures/digitized-theses/dspace_item_digitized_thesis.json
+++ b/tests/fixtures/digitized-theses/dspace_item_digitized_thesis.json
@@ -1,0 +1,301 @@
+{
+    "handle": "1721.1/157046",
+    "id": "48a44352-9152-4470-bae6-547005167d43",
+    "lastModified": "2025-10-30T17:03:44.161+00:00",
+    "links": {
+        "accessStatus": {
+            "href": "https://dspace.mit.edu/server/api/core/items/48a44352-9152-4470-bae6-547005167d43/accessStatus"
+        },
+        "bundles": {
+            "href": "https://dspace.mit.edu/server/api/core/items/48a44352-9152-4470-bae6-547005167d43/bundles"
+        },
+        "identifiers": {
+            "href": "https://dspace.mit.edu/server/api/core/items/48a44352-9152-4470-bae6-547005167d43/identifiers"
+        },
+        "mappedCollections": {
+            "href": "https://dspace.mit.edu/server/api/core/items/48a44352-9152-4470-bae6-547005167d43/mappedCollections"
+        },
+        "metrics": {
+            "href": "https://dspace.mit.edu/server/api/core/items/48a44352-9152-4470-bae6-547005167d43/metrics"
+        },
+        "owningCollection": {
+            "href": "https://dspace.mit.edu/server/api/core/items/48a44352-9152-4470-bae6-547005167d43/owningCollection"
+        },
+        "relationships": {
+            "href": "https://dspace.mit.edu/server/api/core/items/48a44352-9152-4470-bae6-547005167d43/relationships"
+        },
+        "self": {
+            "href": "https://dspace.mit.edu/server/api/core/items/48a44352-9152-4470-bae6-547005167d43"
+        },
+        "submitter": {
+            "href": "https://dspace.mit.edu/server/api/core/items/48a44352-9152-4470-bae6-547005167d43/submitter"
+        },
+        "templateItemOf": {
+            "href": "https://dspace.mit.edu/server/api/core/items/48a44352-9152-4470-bae6-547005167d43/templateItemOf"
+        },
+        "thumbnail": {
+            "href": "https://dspace.mit.edu/server/api/core/items/48a44352-9152-4470-bae6-547005167d43/thumbnail"
+        },
+        "version": {
+            "href": "https://dspace.mit.edu/server/api/core/items/48a44352-9152-4470-bae6-547005167d43/version"
+        }
+    },
+    "metadata": {
+        "dc.contributor.advisor": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": null,
+                "place": 0,
+                "value": "John Harvey Slater."
+            }
+        ],
+        "dc.contributor.author": [
+            {
+                "authority": null,
+                "confidence": 0,
+                "language": "en_US",
+                "place": 0,
+                "value": "McClure, Ghyslaine."
+            }
+        ],
+        "dc.contributor.department": [
+            {
+                "authority": null,
+                "confidence": 500,
+                "language": "en_US",
+                "place": 0,
+                "value": "Massachusetts Institute of Technology. Department of Civil Engineering"
+            }
+        ],
+        "dc.contributor.other": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "Massachusetts Institute of Technology. Department of Civil Engineering."
+            }
+        ],
+        "dc.date.accessioned": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": null,
+                "place": 0,
+                "value": "2024-09-25T21:55:28Z"
+            }
+        ],
+        "dc.date.available": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": null,
+                "place": 0,
+                "value": "2024-09-25T21:55:28Z"
+            }
+        ],
+        "dc.date.copyright": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "1984"
+            }
+        ],
+        "dc.date.issued": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "1984"
+            }
+        ],
+        "dc.description": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "Thesis: M.S., Massachusetts Institute of Technology, Department of Civil Engineering, 1984"
+            },
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 1,
+                "value": "Vita."
+            },
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 2,
+                "value": "Bibliography: leaves 110-114."
+            }
+        ],
+        "dc.description.collection": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "M.S. Massachusetts Institute of Technology, Department of Civil Engineering"
+            }
+        ],
+        "dc.description.degree": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "M.S."
+            }
+        ],
+        "dc.description.provenance": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en",
+                "place": 1,
+                "value": "Provenance field added on 2024-09-26T03:45:00Z (GMT). due to a bitstream add. No. of bitstreams: 4\\n12854433-MIT.pdf.jpg: 3499 bytes, checksum: 82adc6b916fdedc290c96b0798806514 (MD5)\\n12854433-MIT.pdf.txt: 223009 bytes, checksum: a4022dcdbe5c203708ec0cce1b3e211e (MD5)\\naleph metadata.xml: 7661 bytes, checksum: 6ca6bb74ec8705e6e1d13b393a08c29c (MD5)\\n12854433-MIT.pdf: 38504114 bytes, checksum: 683f3dcb23c43db703eb86e0443f95a7 (MD5)"
+            },
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en",
+                "place": 2,
+                "value": "Provenance field added on 2024-09-25T21:55:51Z (GMT). due to a bitstream add. No. of bitstreams: 2\\n12854433-MIT.pdf: 38504114 bytes, checksum: 683f3dcb23c43db703eb86e0443f95a7 (MD5)\\naleph metadata.xml: 7661 bytes, checksum: 6ca6bb74ec8705e6e1d13b393a08c29c (MD5)"
+            },
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en",
+                "place": 3,
+                "value": "Made available in DSpace on 2024-09-25T21:55:28Z (GMT). No. of bitstreams: 0\\n  Previous issue date: 1984"
+            }
+        ],
+        "dc.description.statementofresponsibility": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "by Ghyslaine McClure."
+            }
+        ],
+        "dc.format.extent": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "xiii, 183 leaves"
+            }
+        ],
+        "dc.identifier.oclc": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "12854433"
+            }
+        ],
+        "dc.identifier.uri": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": null,
+                "place": 0,
+                "value": "https://hdl.handle.net/1721.1/157046"
+            }
+        ],
+        "dc.publisher": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "Massachusetts Institute of Technology"
+            }
+        ],
+        "dc.rights": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "MIT theses may be protected by copyright. Please reuse MIT thesis content according to the MIT Libraries Permissions Policy, which is available through the URL provided."
+            }
+        ],
+        "dc.rights.uri": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "http://dspace.mit.edu/handle/1721.1/7582"
+            }
+        ],
+        "dc.subject": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "Civil Engineering."
+            }
+        ],
+        "dc.title": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "Geometric nonlinearities in guyed towers"
+            }
+        ],
+        "dc.type": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "Thesis"
+            }
+        ],
+        "dspace.entity.type": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": null,
+                "place": 0,
+                "value": "Publication"
+            }
+        ],
+        "dspace.imported": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "2024-09-25T21:55:28Z"
+            }
+        ],
+        "mit.thesis.degree": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "Master"
+            }
+        ]
+    },
+    "name": "Geometric nonlinearities in guyed towers",
+    "type": "item",
+    "uuid": "48a44352-9152-4470-bae6-547005167d43"
+}

--- a/tests/fixtures/digitized-theses/dspace_item_electronic_thesis.json
+++ b/tests/fixtures/digitized-theses/dspace_item_electronic_thesis.json
@@ -1,0 +1,310 @@
+{
+    "handle": "1721.1/66312",
+    "id": "3b19bd5a-ce65-4ae1-8510-7a3fe3c6e508",
+    "lastModified": "2022-01-13T07:54:29.912+00:00",
+    "links": {
+        "accessStatus": {
+            "href": "https://dspace.mit.edu/server/api/core/items/3b19bd5a-ce65-4ae1-8510-7a3fe3c6e508/accessStatus"
+        },
+        "bundles": {
+            "href": "https://dspace.mit.edu/server/api/core/items/3b19bd5a-ce65-4ae1-8510-7a3fe3c6e508/bundles"
+        },
+        "identifiers": {
+            "href": "https://dspace.mit.edu/server/api/core/items/3b19bd5a-ce65-4ae1-8510-7a3fe3c6e508/identifiers"
+        },
+        "mappedCollections": {
+            "href": "https://dspace.mit.edu/server/api/core/items/3b19bd5a-ce65-4ae1-8510-7a3fe3c6e508/mappedCollections"
+        },
+        "metrics": {
+            "href": "https://dspace.mit.edu/server/api/core/items/3b19bd5a-ce65-4ae1-8510-7a3fe3c6e508/metrics"
+        },
+        "owningCollection": {
+            "href": "https://dspace.mit.edu/server/api/core/items/3b19bd5a-ce65-4ae1-8510-7a3fe3c6e508/owningCollection"
+        },
+        "relationships": {
+            "href": "https://dspace.mit.edu/server/api/core/items/3b19bd5a-ce65-4ae1-8510-7a3fe3c6e508/relationships"
+        },
+        "self": {
+            "href": "https://dspace.mit.edu/server/api/core/items/3b19bd5a-ce65-4ae1-8510-7a3fe3c6e508"
+        },
+        "submitter": {
+            "href": "https://dspace.mit.edu/server/api/core/items/3b19bd5a-ce65-4ae1-8510-7a3fe3c6e508/submitter"
+        },
+        "templateItemOf": {
+            "href": "https://dspace.mit.edu/server/api/core/items/3b19bd5a-ce65-4ae1-8510-7a3fe3c6e508/templateItemOf"
+        },
+        "thumbnail": {
+            "href": "https://dspace.mit.edu/server/api/core/items/3b19bd5a-ce65-4ae1-8510-7a3fe3c6e508/thumbnail"
+        },
+        "version": {
+            "href": "https://dspace.mit.edu/server/api/core/items/3b19bd5a-ce65-4ae1-8510-7a3fe3c6e508/version"
+        }
+    },
+    "metadata": {
+        "dc.contributor.advisor": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "Jes\\u00fas A. del Alamo."
+            }
+        ],
+        "dc.contributor.author": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "Oyebode, Olayemi A. F. (Olayemi Abiodun Folaranmi)"
+            }
+        ],
+        "dc.contributor.department": [
+            {
+                "authority": null,
+                "confidence": 600,
+                "language": null,
+                "place": 0,
+                "value": "Massachusetts Institute of Technology. Department of Electrical Engineering and Computer Science"
+            }
+        ],
+        "dc.contributor.other": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "Massachusetts Institute of Technology. Dept. of Electrical Engineering and Computer Science."
+            }
+        ],
+        "dc.date.accessioned": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": null,
+                "place": 0,
+                "value": "2011-10-17T19:49:25Z"
+            }
+        ],
+        "dc.date.available": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": null,
+                "place": 0,
+                "value": "2011-10-17T19:49:25Z"
+            }
+        ],
+        "dc.date.copyright": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "2011"
+            }
+        ],
+        "dc.date.issued": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "2011"
+            }
+        ],
+        "dc.description": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "Thesis (M. Eng.)--Massachusetts Institute of Technology, Dept. of Electrical Engineering and Computer Science, 2011."
+            },
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 1,
+                "value": "This electronic version was submitted by the student author.  The certified thesis is available in the Institute Archives and Special Collections."
+            },
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 2,
+                "value": "Cataloged from student submitted PDF version of thesis."
+            },
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 3,
+                "value": "Includes bibliographical references (p. 62-63)."
+            }
+        ],
+        "dc.description.abstract": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "The MIT iLab project has developed online laboratories called iLabs that allow students to conduct real experiments on real equipment over the Internet. The ELVIS iLab, developed using National Instruments' Educational Laboratory Virtual Instrument Suite, has made it possible for students to develop a better understanding of engineering concepts by obtaining real data from an electronics lab. In the latest version of the ELVIS iLab, developed in this thesis, the user interface is redesigned to incorporate new features that will improve the experience of students and create new learning opportunities for students. As a result, students can enter values for parameters in the experiment more intuitively, have multiple experiments open simultaneously, view more variables in the graphs by adding new axes and defining new plots, retrieve earlier experiments and choose whether to connect or disconnect circuit elements."
+            }
+        ],
+        "dc.description.degree": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "M.Eng."
+            }
+        ],
+        "dc.description.provenance": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en",
+                "place": 0,
+                "value": "Made available in DSpace on 2011-10-17T19:49:25Z (GMT). No. of bitstreams: 2\\n755804116.pdf: 7167055 bytes, checksum: 7e4c8744d85accbd609a525103257798 (MD5)\\n755804116-MIT.pdf: 7142547 bytes, checksum: 6267929057c6c0b919f0b936e7b20ad3 (MD5)\\n  Previous issue date: 2011; Curation Task, LiberateTheses, removed 1 bitstream, 755804116.pdf, on 2015-04-27T21:42:47Z (GMT).; Curation Task, RemoveNonPrintingExtractedTextFromLiberatedTheses, removed 1 bitstream, 755804116.pdf.txt, on 2015-07-22T17:39:35Z (GMT)."
+            },
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en",
+                "place": 1,
+                "value": "Provenance field added on 2019-04-12T20:58:17Z (GMT). due to a bitstream add. No. of bitstreams: 3\\n755804116-MIT.pdf.jpg: 3725 bytes, checksum: da74252268a1dda696590fa579258ba9 (MD5)\\n755804116-MIT.pdf: 7142547 bytes, checksum: 6267929057c6c0b919f0b936e7b20ad3 (MD5)\\n755804116-MIT.pdf.txt: 82460 bytes, checksum: 3804910fff7d72628fc3ab8d5ee75d38 (MD5)"
+            }
+        ],
+        "dc.description.statementofresponsibility": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "by Olayemi A. F. Oyebode."
+            }
+        ],
+        "dc.format.extent": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "63 p."
+            }
+        ],
+        "dc.identifier.oclc": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "755804116"
+            }
+        ],
+        "dc.identifier.uri": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": null,
+                "place": 0,
+                "value": "http://hdl.handle.net/1721.1/66312"
+            }
+        ],
+        "dc.language.iso": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "eng"
+            }
+        ],
+        "dc.publisher": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "Massachusetts Institute of Technology"
+            }
+        ],
+        "dc.rights": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "M.I.T. theses are protected by \\ncopyright. They may be viewed from this source for any purpose, but \\nreproduction or distribution in any format is prohibited without written \\npermission. See provided URL for inquiries about permission."
+            }
+        ],
+        "dc.rights.uri": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "http://dspace.mit.edu/handle/1721.1/7582"
+            }
+        ],
+        "dc.subject": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "Electrical Engineering and Computer Science."
+            }
+        ],
+        "dc.title": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "A new client Interface for the ELVIS iLab with enhanced capabilities"
+            }
+        ],
+        "dc.title.alternative": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "New client Interface for the Educational Laboratory Virtual Instrument Suite iLab with enhanced capabilities"
+            }
+        ],
+        "dc.type": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": "en_US",
+                "place": 0,
+                "value": "Thesis"
+            }
+        ],
+        "dspace.authorsordered": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": null,
+                "place": 0,
+                "value": "false"
+            }
+        ],
+        "dspace.entity.type": [
+            {
+                "authority": null,
+                "confidence": -1,
+                "language": null,
+                "place": 0,
+                "value": "Publication"
+            }
+        ]
+    },
+    "name": "A new client Interface for the ELVIS iLab with enhanced capabilities",
+    "type": "item",
+    "uuid": "3b19bd5a-ce65-4ae1-8510-7a3fe3c6e508"
+}

--- a/tests/workflows/digitized_theses/test_workflow.py
+++ b/tests/workflows/digitized_theses/test_workflow.py
@@ -1,0 +1,266 @@
+# ruff: noqa: SLF001
+import glob
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from dspace_rest_client.models import Item as DSpaceItem
+from freezegun import freeze_time
+from lxml import etree
+
+from dsc import exceptions
+from dsc.item_submission import ItemSubmission
+from dsc.workflows.digitized_theses import (
+    DigitizedTheses,
+)
+
+# =========================
+# DSpace client and items
+# =========================
+
+
+@pytest.fixture
+def mock_dspace_client():
+    """A MagicMock standing in for an authenticated DSpaceClient."""
+    client = MagicMock(name="DSpaceClient")
+    client.authenticate.return_value = True
+    return client
+
+
+@pytest.fixture
+def patched_dspace_client(mock_dspace_client):
+    """Patch DSpaceClient.
+
+    Patches DSpaceClient at the location it's imported in workflow.py.
+    """
+    with patch("dsc.workflows.digitized_theses.workflow.DSpaceClient") as dspace_client:
+        dspace_client.return_value = mock_dspace_client
+        yield dspace_client
+
+
+@pytest.fixture
+def dspace_item_digitized_thesis():
+    """Item for a digitized (non-electronic) thesis.
+
+    Content of an Item object returned by the search_objects() method
+    of dspace_rest_client.client.DSpaceClient.
+    """
+    with open(
+        "tests/fixtures/digitized-theses/dspace_item_digitized_thesis.json"
+    ) as file:
+        content = json.load(file)
+
+    return DSpaceItem(content)
+
+
+@pytest.fixture
+def dspace_item_electronic_thesis():
+    """Item for an electronic (student-submitted) thesis.
+
+    Content of an Item object returned by the search_objects() method
+    of dspace_rest_client.client.DSpaceClient.
+    """
+    with open(
+        "tests/fixtures/digitized-theses/dspace_item_electronic_thesis.json"
+    ) as file:
+        content = json.load(file)
+
+    return DSpaceItem(content)
+
+
+# ====================
+# Alma SRU responses
+# ====================
+
+
+@pytest.fixture
+def alma_sru_response_single_record():
+    with open(
+        "tests/fixtures/digitized-theses/alma_sru_response_single_record.xml", "rb"
+    ) as file:
+        return file.read()
+
+
+@pytest.fixture
+def alma_sru_response_multiple_records():
+    """Alma SRU response when multiple records are returned.
+
+    The content for this fixture only highlights the tag that the workflow
+    method for parsing a record relies on: {http://www.loc.gov/zing/srw/}numberOfRecords.
+    """
+    with open(
+        "tests/fixtures/digitized-theses/alma_sru_response_multiple_records.xml", "rb"
+    ) as file:
+        return file.read()
+
+
+@pytest.fixture
+def alma_sru_response_no_record():
+    with open(
+        "tests/fixtures/digitized-theses/alma_sru_response_no_record.xml", "rb"
+    ) as file:
+        return file.read()
+
+
+# ====================
+# S3 bucket contents
+# ====================
+
+
+@pytest.fixture
+def mock_s3_digitized_theses(mocked_s3, s3_client):
+    for source_metadata_file in glob.glob(
+        "tests/fixtures/digitized-theses/batch-aaa/*/*.xml"
+    ):
+        with open(source_metadata_file, "rb") as file:
+            s3_client.put_file(
+                bucket="dsc",
+                key=source_metadata_file.replace("tests/fixtures/", ""),
+                file_content=file.read(),
+            )
+
+
+def test_workflow_dspace_client_init(mock_dspace_client, patched_dspace_client):
+    workflow = DigitizedTheses(batch_id="batch-aaa")
+    _ = workflow.dspace_client
+
+    mock_dspace_client.authenticate.assert_called_once()
+    patched_dspace_client.assert_called_once_with(
+        api_endpoint="mock://mit-dspace.test.4science.cloud/server/api",
+        username="user@test.com",
+        password="topsecret",  # noqa: S106
+        fake_user_agent=True,
+    )
+
+
+def test_workflow_dspace_client_raise_authentication_error(
+    mock_dspace_client, patched_dspace_client
+):
+    mock_dspace_client.authenticate.return_value = False
+    workflow = DigitizedTheses(batch_id="batch-aaa")
+
+    with pytest.raises(exceptions.DSpaceClientAuthenticationError):
+
+        _ = workflow.dspace_client
+
+
+@freeze_time("2025-01-01 09:00:00")
+def test_workflow_update_batch_id():
+    workflow = DigitizedTheses(batch_id="batch-aaa")
+
+    assert workflow._update_batch_id(batch_id="batch-aaa") == "batch-aaa-20250101T090000Z"
+
+
+@patch("dsc.workflows.digitized_theses.workflow.requests")
+def test_workflow_download_metadata_from_alma(
+    mock_requests, alma_sru_response_single_record, tmp_path
+):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = alma_sru_response_single_record
+    mock_requests.get.return_value = mock_response
+
+    workflow = DigitizedTheses(batch_id="batch-aaa")
+    workflow._download_metadata_from_alma(
+        item_submission=ItemSubmission(
+            batch_id="batch-aaa",
+            item_identifier="36570527",
+            workflow_name=workflow.workflow_name,
+        ),
+        batch_location=tmp_path,
+    )
+
+    assert os.path.exists(tmp_path / "36570527.xml")
+
+
+def test_workflow_get_item_from_dspace(
+    mock_dspace_client, patched_dspace_client, dspace_item_digitized_thesis
+):
+    mock_dspace_client.search_objects.return_value = [dspace_item_digitized_thesis]
+
+    workflow = DigitizedTheses(batch_id="batch-aaa")
+    result = workflow._get_item_from_dspace(item_identifier="12854433")
+
+    assert result == dspace_item_digitized_thesis
+
+
+def test_workflow_move_batch_files_to_theses_subfolders(tmp_path):
+    """Verifies that theses are organized by `ItemSubmission.status_details`."""
+    workflow = DigitizedTheses(batch_id="batch-aaa")
+    workflow._move_batch_files_to_theses_subfolders(
+        item_submissions=[
+            ItemSubmission(
+                batch_id="batch-aaa",
+                item_identifier="001",
+                workflow_name=workflow.workflow_name,
+                status_details="Replacement thesis",
+            ),
+            ItemSubmission(
+                batch_id="batch-aaa",
+                item_identifier="002",
+                workflow_name=workflow.workflow_name,
+                status_details="New thesis",
+            ),
+            ItemSubmission(
+                batch_id="batch-aaa",
+                item_identifier="003",
+                workflow_name=workflow.workflow_name,
+                status_details="Error occurred",
+            ),
+        ],
+        batch_location=tmp_path,
+    )
+
+    assert os.path.exists(tmp_path / "replacement-theses/001")
+    assert os.path.exists(tmp_path / "new-theses/002")
+    assert os.path.exists(tmp_path / "skipped-theses/003")
+
+
+def test_workflow_is_replacement_thesis_if_digitized_returns_true(
+    dspace_item_digitized_thesis,
+):
+    workflow = DigitizedTheses(batch_id="batch-aaa")
+
+    assert workflow._is_replacement_thesis(dspace_item_digitized_thesis)
+
+
+def test_workflow_is_replacement_thesis_if_electronic_returns_false(
+    dspace_item_electronic_thesis,
+):
+    workflow = DigitizedTheses(batch_id="batch-aaa")
+
+    assert not workflow._is_replacement_thesis(dspace_item_electronic_thesis)
+
+
+def test_workflow_parse_record_from_sru_response_single_records(
+    alma_sru_response_single_record,
+):
+    workflow = DigitizedTheses(batch_id="batch-aaa")
+
+    record = workflow._parse_record_from_sru_response(alma_sru_response_single_record)
+
+    assert isinstance(record, etree._Element)
+    assert record.tag == "{http://www.loc.gov/MARC21/slim}record"
+
+
+def test_workflow_parse_record_from_sru_response_multiple_records(
+    alma_sru_response_multiple_records,
+):
+    workflow = DigitizedTheses(batch_id="batch-aaa")
+
+    with pytest.raises(exceptions.ItemMetadataNotFoundError):
+        workflow._parse_record_from_sru_response(alma_sru_response_multiple_records)
+
+
+def test_workflow_parse_record_from_sru_response_no_records(alma_sru_response_no_record):
+    workflow = DigitizedTheses(batch_id="batch-aaa")
+
+    with pytest.raises(exceptions.ItemMetadataNotFoundError):
+        workflow._parse_record_from_sru_response(alma_sru_response_no_record)
+
+
+def test_workflow_parse_item_identifier():
+    workflow = DigitizedTheses(batch_id="batch-aaa")
+
+    assert workflow.parse_item_identifier("s3://bucket/prefix/123456-MIT.pdf") == "123456"

--- a/uv.lock
+++ b/uv.lock
@@ -36,25 +36,26 @@ wheels = [
 
 [[package]]
 name = "ast-serialize"
-version = "0.3.0"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a9/9d/912fefab0e30aee6a3af8a62bbea4a81b29afa4ba2c973d31170620a26de/ast_serialize-0.3.0.tar.gz", hash = "sha256:1bc3ca09a63a021376527c4e938deedd11d11d675ce850e6f9c7487f5889992b", size = 60689, upload-time = "2026-04-30T23:24:48.104Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/9d/09e27731bd5864a9ce04e3244074e674bb8936bf62b45e0357248717adac/ast_serialize-0.5.0.tar.gz", hash = "sha256:5880091bfe6f4f986f22866375c2e884843e7a0b6343ae41aeea659613d879b6", size = 61157, upload-time = "2026-05-17T17:48:29.429Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/93/72abad83966ed6235647c9f956417dc1e17e997696388521910e3d1fa3f4/ast_serialize-0.3.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:2ec2fafa5e4313cc8feed96e436ebe19ac7bc6fa41fbc2827e826c48b9e4c3a9", size = 1190024, upload-time = "2026-04-30T23:24:22.486Z" },
-    { url = "https://files.pythonhosted.org/packages/85/4f/eb88584b2f0234e581762011208ca203252bf6c98e59b4769daa571f3576/ast_serialize-0.3.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ef6d3c08b7b4cd29b48410338e134764a00e76d25841eb02c1084e868c888ecc", size = 1178633, upload-time = "2026-04-30T23:24:24.35Z" },
-    { url = "https://files.pythonhosted.org/packages/56/51/cf1ec1ff3e616373d0dcbd5fad502e0029dc541f13ab642259762a7d127f/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d841424f41b886e98044abc80769c14a956e6e5ccd5fb5b0d9f5ead72be18a4", size = 1241351, upload-time = "2026-04-30T23:24:25.987Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/44/68fcf50478cf1093f2d423f034ae06453122c8b415d8e21a44668eca485d/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d21453734ad39367ede5d37efe4f59f830ce1c09f432fc72a90e368f77a4a3e7", size = 1239582, upload-time = "2026-04-30T23:24:27.808Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/c1/a6c9fa284eceb5fc6f21347e968445a051d7ca2c4d34e6a04314646dbcee/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f5e110cdce2a347e1dd987529c88ef54d26f67848dce3eba1b3b2cc2cf085c94", size = 1448853, upload-time = "2026-04-30T23:24:29.534Z" },
-    { url = "https://files.pythonhosted.org/packages/23/5f/8ad3829a09e4e8c5328a53ce7d4711d660944e3e164c5f6abcc2c8f27167/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b6e23a98e57560a055f5c4b68700a0fd5ce483d2814c23140b3638c7f5d1e61", size = 1262204, upload-time = "2026-04-30T23:24:31.482Z" },
-    { url = "https://files.pythonhosted.org/packages/25/13/44aa28d97f10e25247e8576b5f6b2795d4fa1a80acc88acc942c508d06f7/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1c9e763d70293d65ce1e1ea8c943140c68d0953f0268c7ee0998f2e07f77dd0", size = 1266458, upload-time = "2026-04-30T23:24:33.088Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/58/b3a8be3777cd3744324fd5cec0d80d37cd96fc7cbb0fb010e03dff1e870f/ast_serialize-0.3.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4388a1796c228f1ce5c391426f7d21a0003ad3b47f677dbeded9bd1a85c7209f", size = 1308700, upload-time = "2026-04-30T23:24:34.657Z" },
-    { url = "https://files.pythonhosted.org/packages/13/03/f8312d6b57f5471a9dc7946f22b8798a1fc296d38c25766223aacadec42c/ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5283cdcc0c64c3d8b9b688dc6aaa012d9c0cf1380a7f774a6bae6a1c01b3205a", size = 1416724, upload-time = "2026-04-30T23:24:36.562Z" },
-    { url = "https://files.pythonhosted.org/packages/50/5d/13fc3789a7abac00559da2e2e9f386db4612aa1f84fc53d09bf714c37545/ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:f5ef88cc5842a5d7a6ac09dc0d5fc2c98f5d276c1f076f866d55047ce886785b", size = 1515441, upload-time = "2026-04-30T23:24:38.018Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/b9/7ab43fc7a23b1f970281093228f5f79bed6edeed7a3e672bde6d7a832a58/ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cc14bf402bdc0978594ecce783793de2c7470cd4f5cd7eb286ca97ed8ff7cba9", size = 1510522, upload-time = "2026-04-30T23:24:39.798Z" },
-    { url = "https://files.pythonhosted.org/packages/56/ec/d75fc2b788d319f1fad77c14156896f31afdfc68af85b505e5bdebcb9592/ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11eae0cf1b7b3e0678133cc2daa974ea972caf02eb4b3aa062af6fa9acd52c57", size = 1460917, upload-time = "2026-04-30T23:24:41.305Z" },
-    { url = "https://files.pythonhosted.org/packages/95/74/f99c81193a2725911e1911ae567ed27c2f2419332c7f3537366f9d238cac/ast_serialize-0.3.0-cp39-abi3-win32.whl", hash = "sha256:2db3dd99de5e6a5a11d7dda73de8750eb6e5baaf25245adf7bdcfe64b6108ae2", size = 1067804, upload-time = "2026-04-30T23:24:43.091Z" },
-    { url = "https://files.pythonhosted.org/packages/16/81/76af00c47daa151e89f98ae21fbbcb2840aaa9f5766579c4da76a3c57188/ast_serialize-0.3.0-cp39-abi3-win_amd64.whl", hash = "sha256:a2cd125adccf7969470621905d302750cd25951f22ea430d9a25b7be031e5549", size = 1105561, upload-time = "2026-04-30T23:24:44.578Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/46/d3ec57ad500f598d1554bd14ce4df615960549ab2844961bc4e1f5fbd174/ast_serialize-0.3.0-cp39-abi3-win_arm64.whl", hash = "sha256:0dd00da29985f15f50dc35728b7e1e7c84507bccfea1d9914738530f1c72238a", size = 1077165, upload-time = "2026-04-30T23:24:46.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9e/dc2530acb3a60dc6e46d65abf27d1d9f86721694757906a148d90a6860de/ast_serialize-0.5.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:0668aa9459cfa8c9c49ddd2163ebcf43088ba045ef7492af6fe22e0098303101", size = 1191380, upload-time = "2026-05-17T17:48:03.738Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0a/bd3d18a582f273d6c843d16bb9e22e9e16365ff7991e92f18f798e9f1224/ast_serialize-0.5.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bf683d6363edf2b39eed6b6d4fe22d34b6203867a67e27134d9e2a2680c4bc4a", size = 1183879, upload-time = "2026-05-17T17:48:05.463Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/1f919100f8620887af58fcc381c61a1f218cdf89c6e155f87b213e61010a/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cc22cf0c9be65e71cf88fda130af60d61eb4a79370ad4cfe7900d48a4aa2211", size = 1244529, upload-time = "2026-05-17T17:48:07.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ca/6376559dcce707cdbc1d0d9a13c8d3baaaa501e949ce0ebdc4230cd881aa/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f66173891548c9f2726bf27957b41cabce12fa679dc6da505ddbde4d4b3b31cf", size = 1240560, upload-time = "2026-05-17T17:48:08.46Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b2/a620e206b5aeb7efbf2710336df57d457cffbb3991076bbcc1147ef9abd4/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e42d729ef2be96a14efbad355093284739e3670ece3e534f82cc8832790911d9", size = 1451172, upload-time = "2026-05-17T17:48:09.922Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/e0/4ad5c04c24a40481b2935ce9a0ccdb6023dc8b667167d06ae530cc3512f2/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b725026bafa801dbd7310eb13a75f0a2e370e7e51b2cb225f9d21fcfadf919ee", size = 1265072, upload-time = "2026-05-17T17:48:11.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/71/4d1d479aa56d0101c40e17720c3d6ac2af7269ea0487a80b18e7bfd1a5b7/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b54f60c1d78767a53b67eaa663f0dfac3afe606aa07f1301572f588b73d64809", size = 1270488, upload-time = "2026-05-17T17:48:13.575Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/4f/0de1bbe06f6edef9fde4ed12ca8e7b3ec7e6e2bd4e672c5af487f7957665/ast_serialize-0.5.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:27d51654fc240a1e87e742d353d98eb45b75f62f129086b3596ab53df2ac2a43", size = 1260702, upload-time = "2026-05-17T17:48:15.141Z" },
+    { url = "https://files.pythonhosted.org/packages/75/61/e00872439cfdddcc3c1b6cdaa6e5d904ba8e26a18807c67c4e14409d0ca8/ast_serialize-0.5.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c36237c46dd1674542f2109740ea5ea485a169bf1431939ada0434e17934", size = 1311182, upload-time = "2026-05-17T17:48:16.779Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8e/699a5b955f7926956c95e9e1d74132acad73c2fe7a426f94da89123c20aa/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1943db345233cc7194a470f13afa9c59772c0b123dea0c9414c4d4ca54369759", size = 1421410, upload-time = "2026-05-17T17:48:18.527Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ae/d5b7626874478997adc7a29ab28accf21e596fb590c944290401dfd0b29e/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:df1c00022cbbcb064bfaa505aa9c9295362443ce5dacb459d1331d3da353f887", size = 1516587, upload-time = "2026-05-17T17:48:20.133Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ce/b59e02a82d9c4244d64cde502e0b00e83e38816abe19155ceb5437402c7f/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cae65289fc456fde04af979a2be09302ef5d8ab92ef23e596d6746dc267ada27", size = 1515171, upload-time = "2026-05-17T17:48:21.921Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/38/d8d90042747d05aa08d4efcf1c99035a5f670a6bf4c214d31644392afbca/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:239a4c354e8d676e9d94631d1d4a64edc6b266f86ff3a5a80aedd344f342c01d", size = 1464668, upload-time = "2026-05-17T17:48:23.544Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/51/5b840c4df7334104cecffa28f23904fe81ca89ca223d2450e288de39fd3c/ast_serialize-0.5.0-cp39-abi3-win32.whl", hash = "sha256:143a4ef63285a075871908fda3672dc21864b83a8ec3ee12304aa3e4c5387b9a", size = 1068311, upload-time = "2026-05-17T17:48:25.027Z" },
+    { url = "https://files.pythonhosted.org/packages/41/11/ca5672c7d491825bc4cd6702dea106a6b60d928707712ec257c7833ae476/ast_serialize-0.5.0-cp39-abi3-win_amd64.whl", hash = "sha256:cf25572c526add400f26a4750dc6ce0c3bb93fc1f75e7ae0cad4ce4f2cd5c590", size = 1108931, upload-time = "2026-05-17T17:48:26.591Z" },
+    { url = "https://files.pythonhosted.org/packages/45/19/cc8bd127d28a43da249aa955cfd164cf8fd534e79e42cea96c4854d72fd0/ast_serialize-0.5.0-cp39-abi3-win_arm64.whl", hash = "sha256:92a31c9c20d25a076edaeec76b128a3535d74a24f340b9a8a7e96c9b86dc9642", size = 1081181, upload-time = "2026-05-17T17:48:28.122Z" },
 ]
 
 [[package]]
@@ -104,8 +105,83 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-common"
+version = "1.1.28"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/71/f6f71a276e2e69264a97ad39ef850dca0a04fce67b12570730cb38d0ccac/azure-common-1.1.28.zip", hash = "sha256:4ac0cd3214e36b6a1b6a442686722a5d8cc449603aa833f3f0f40bda836704a3", size = 20914, upload-time = "2022-02-03T19:39:44.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/55/7f118b9c1b23ec15ca05d15a578d8207aa1706bc6f7c87218efffbbf875d/azure_common-1.1.28-py2.py3-none-any.whl", hash = "sha256:5c12d3dcf4ec20599ca6b0d3e09e86e146353d443e7fcc050c9a19c1f9df20ad", size = 14462, upload-time = "2022-02-03T19:39:42.417Z" },
+]
+
+[[package]]
+name = "azure-core"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f3/b416179e408990df5db0d516283022dde0f5d0111d98c1a848e41853e81c/azure_core-1.41.0.tar.gz", hash = "sha256:f46ff5dfcd230f25cf1c19e8a34b8dc08a337b2503e268bb600a16c00db8ad5a", size = 381042, upload-time = "2026-05-07T23:30:54.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/db/325c6d7312d2200251c52323878281045aaffcb5586612296484e4280eaa/azure_core-1.41.0-py3-none-any.whl", hash = "sha256:522b4011e8180b1a3dcd2024396a4e7fe9ac37fb8597db47163d230b5efe892d", size = 220920, upload-time = "2026-05-07T23:30:56.357Z" },
+]
+
+[[package]]
+name = "azure-storage-blob"
+version = "12.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/25/fdcf1e381922dbab8ba23d6fd78d397fe6cbac6b480310218834b7bc91fe/azure_storage_blob-12.29.0.tar.gz", hash = "sha256:2824ddd7ebc9056034ebc76b17971a38e9aa5835abb0d565b9700493f2a6c657", size = 611359, upload-time = "2026-05-15T03:34:59.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/2c/6ddee6a3e42d0236ba9259e4df7fa97fdc415ff0802b736c634baaf4b285/azure_storage_blob-12.29.0-py3-none-any.whl", hash = "sha256:ccf8a1bcd5e49df83ab85aab793b579e5ba2eeea2ad8900b2f62ca3a37dc391f", size = 434823, upload-time = "2026-05-15T03:35:01.837Z" },
+]
+
+[[package]]
+name = "bcrypt"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/29/6237f151fbfe295fe3e074ecc6d44228faa1e842a81f6d34a02937ee1736/bcrypt-5.0.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b", size = 494553, upload-time = "2025-09-25T19:49:49.006Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009, upload-time = "2025-09-25T19:49:50.581Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029, upload-time = "2025-09-25T19:49:52.533Z" },
+    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907, upload-time = "2025-09-25T19:49:54.709Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7e/d4e47d2df1641a36d1212e5c0514f5291e1a956a7749f1e595c07a972038/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2b732e7d388fa22d48920baa267ba5d97cca38070b69c0e2d37087b381c681fd", size = 296500, upload-time = "2025-09-25T19:49:56.013Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412, upload-time = "2025-09-25T19:49:57.356Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486, upload-time = "2025-09-25T19:49:59.116Z" },
+    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940, upload-time = "2025-09-25T19:50:00.869Z" },
+    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776, upload-time = "2025-09-25T19:50:02.393Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922, upload-time = "2025-09-25T19:50:04.232Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367, upload-time = "2025-09-25T19:50:05.559Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187, upload-time = "2025-09-25T19:50:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bb/461f352fdca663524b4643d8b09e8435b4990f17fbf4fea6bc2a90aa0cc7/bcrypt-5.0.0-cp38-abi3-win32.whl", hash = "sha256:3abeb543874b2c0524ff40c57a4e14e5d3a66ff33fb423529c88f180fd756538", size = 153752, upload-time = "2025-09-25T19:50:08.515Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/4190e60921927b7056820291f56fc57d00d04757c8b316b2d3c0d1d6da2c/bcrypt-5.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:35a77ec55b541e5e583eb3436ffbbf53b0ffa1fa16ca6782279daf95d146dcd9", size = 150881, upload-time = "2025-09-25T19:50:09.742Z" },
+    { url = "https://files.pythonhosted.org/packages/54/12/cd77221719d0b39ac0b55dbd39358db1cd1246e0282e104366ebbfb8266a/bcrypt-5.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:cde08734f12c6a4e28dc6755cd11d3bdfea608d93d958fffbe95a7026ebe4980", size = 144931, upload-time = "2025-09-25T19:50:11.016Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a", size = 495313, upload-time = "2025-09-25T19:50:12.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290, upload-time = "2025-09-25T19:50:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253, upload-time = "2025-09-25T19:50:15.089Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084, upload-time = "2025-09-25T19:50:16.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/fa6e16145e145e87f1fa351bbd54b429354fd72145cd3d4e0c5157cf4c70/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a71f70ee269671460b37a449f5ff26982a6f2ba493b3eabdd687b4bf35f875ac", size = 297185, upload-time = "2025-09-25T19:50:18.525Z" },
+    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656, upload-time = "2025-09-25T19:50:19.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662, upload-time = "2025-09-25T19:50:21.567Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240, upload-time = "2025-09-25T19:50:23.305Z" },
+    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152, upload-time = "2025-09-25T19:50:24.597Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284, upload-time = "2025-09-25T19:50:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643, upload-time = "2025-09-25T19:50:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698, upload-time = "2025-09-25T19:50:31.347Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
+    { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
+]
+
+[[package]]
 name = "black"
-version = "26.3.1"
+version = "26.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -115,14 +191,14 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pytokens" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/f8/da5eae4fc75e78e6dceb60624e1b9662ab00d6b452996046dfa9b8a6025b/black-26.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1", size = 1895920, upload-time = "2026-03-12T03:40:13.921Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/9f/04e6f26534da2e1629b2b48255c264cabf5eedc5141d04516d9d68a24111/black-26.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f", size = 1718499, upload-time = "2026-03-12T03:40:15.239Z" },
-    { url = "https://files.pythonhosted.org/packages/04/91/a5935b2a63e31b331060c4a9fdb5a6c725840858c599032a6f3aac94055f/black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7", size = 1794994, upload-time = "2026-03-12T03:40:17.124Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/0a/86e462cdd311a3c2a8ece708d22aba17d0b2a0d5348ca34b40cdcbea512e/black-26.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983", size = 1420867, upload-time = "2026-03-12T03:40:18.83Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/e5/22515a19cb7eaee3440325a6b0d95d2c0e88dd180cb011b12ae488e031d1/black-26.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb", size = 1230124, upload-time = "2026-03-12T03:40:20.425Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload-time = "2026-03-12T03:36:01.668Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/7744b906703228264ef73bdd534df88ec1ef3de45c4e78f6d31b9e32d0c9/black-26.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4ad6fa01f941920f54f2bbb35f3df7673428a0ef98a0b0840c2eaef3b110efa8", size = 2012518, upload-time = "2026-05-18T17:05:20.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c0/c5a3b1636dfd09c42534f2b3cf33506814f6d3e066fb0879ffa16c1ae860/black-26.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3915f256e75a2d7cf88d8953d37f780455dc586cc72dee059c528fe77f581217", size = 1816016, upload-time = "2026-05-18T17:05:21.84Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/0e/36044316b65ca471d3bb6d3703fd06fb50c6b727c3562f6a5a3153634f88/black-26.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d98d4137277c75dfb898ec8d846c4fd68ba1e9cf77f95e2865c203dc18f4c3d", size = 1884150, upload-time = "2026-05-18T17:05:23.546Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/33/dafc5808c2af43672912111d7c3354af1615f7e2be3bed7a878461abbe4d/black-26.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:a1dca32d9f1784af512a13410ec204c6f7f0aa9797a111c42e1c03449821c264", size = 1486825, upload-time = "2026-05-18T17:05:25.004Z" },
+    { url = "https://files.pythonhosted.org/packages/82/14/b965ee6ad2a311f28bdbf692def3ee9848d2ae289dab28b27657fcee3e78/black-26.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1037d5ac7b7b310b2632ad867ec8d0e4c4819dcdb0b820f63135da746a24e418", size = 1288646, upload-time = "2026-05-18T17:05:26.477Z" },
+    { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
 ]
 
 [[package]]
@@ -145,29 +221,29 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.6"
+version = "1.43.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/37/78c630d1308964aa9abf44951d9c4df776546ff37251ec2434944e205c4e/boto3-1.43.6.tar.gz", hash = "sha256:e6315effaf12b890b99956e6f8e2c3000a3f64e4ee91943cec3895ce9a836afb", size = 113153, upload-time = "2026-05-07T20:49:59.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/27/ae1a71e945ce7bde39b0677b252fe7d8a0ad7fa3d6b724d78b81469c08fe/boto3-1.43.10.tar.gz", hash = "sha256:27342e5d5f6170fcc8d1e21cdd939af2448d58ac56b08d494250eaad998e30c7", size = 113159, upload-time = "2026-05-18T20:42:34.454Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/e2/3c2eef44f55eafab256836d1d9479bd6a74f70c26cbfdc0639a0e23e4327/boto3-1.43.6-py3-none-any.whl", hash = "sha256:179601ec2992726a718053bf41e43c223ceba397d31ceab11f64d9c910d9fc3a", size = 140502, upload-time = "2026-05-07T20:49:57.8Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/1b/439234598449f846b17333e67ec63c3dd8f8880c13de9089383b4bab58c3/boto3-1.43.10-py3-none-any.whl", hash = "sha256:83918184d95967e4c6e9ed1e9a2f58250b291e6ea2cb847ab0825d52596b39e5", size = 140534, upload-time = "2026-05-18T20:42:32.009Z" },
 ]
 
 [[package]]
 name = "boto3-stubs"
-version = "1.43.6"
+version = "1.43.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore-stubs" },
     { name = "types-s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/8d/a2f47f54455d42071034177ac3c9c0bdfd1b51cab76c854f5619970ac57e/boto3_stubs-1.43.6.tar.gz", hash = "sha256:6c8b2e2977b5f85cdac82f1e3590cd7e7e452c92341654cc64c93a63da0f7bec", size = 102646, upload-time = "2026-05-07T21:15:34.897Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/67/969b5bc0581ef6f22b2371bdc33d66a50fe907993e0528cb34a7f3fa59f7/boto3_stubs-1.43.10.tar.gz", hash = "sha256:05575658b827e7a12a45629e1a987317e1e679dccabe5ebde5a2101528c76cf8", size = 102665, upload-time = "2026-05-18T20:47:00.528Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/26/4c99307c18a3d77781ce585c45f4ff8098ebb44583360f142ed60df31e49/boto3_stubs-1.43.6-py3-none-any.whl", hash = "sha256:ff37a72104c556d7d57a8b0ec2123a6407b7737edd04e8533de5fc736a1d9d63", size = 70656, upload-time = "2026-05-07T21:15:28.95Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/42/90eb347eda878b15def1f0bb0971779b1829a0fc6b9c0fe3ff823de09833/boto3_stubs-1.43.10-py3-none-any.whl", hash = "sha256:0ce5dec421a45ef1b8ddd32e68d0b8bb78ea7447c5ddf8231420ccaa6e71e0f5", size = 70667, upload-time = "2026-05-18T20:46:54.359Z" },
 ]
 
 [package.optional-dependencies]
@@ -186,16 +262,16 @@ ses = [
 
 [[package]]
 name = "botocore"
-version = "1.43.6"
+version = "1.43.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/a7/23d0f5028011455096a1eeac0ddf3cbe147b3e855e127342f8202552194d/botocore-1.43.6.tar.gz", hash = "sha256:b1e395b347356860398da42e61c808cf1e34b6fa7180cf2b9d87d986e1a06ba0", size = 15336070, upload-time = "2026-05-07T20:49:48.14Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/4e/c127dd0628c551f10cb890e279a9c0e367523b880c4cd3e81a1e76886174/botocore-1.43.10.tar.gz", hash = "sha256:2f4af585b41dbccdfc9f49677d7bd72d713a12ef89a1dc9c8538a927649498bf", size = 15365344, upload-time = "2026-05-18T20:42:21.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/c8/6f47223840e8d8cfa8c9f7c0ec1b77970417f257fc885169ff4f6326ce09/botocore-1.43.6-py3-none-any.whl", hash = "sha256:b6d1fdbc6f65a5fe0b7e947823aa37535d3f39f3ba4d21110fab1f55bbbcc04b", size = 15017094, upload-time = "2026-05-07T20:49:44.964Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/0e/41f64d6c267edf03f4fe8f461edc4c644243e77c8d5a1fef1e0166ac4ed0/botocore-1.43.10-py3-none-any.whl", hash = "sha256:8a0176d8c2f8bebe95d4f923a824a1ace04b02f360e220681c388e097f32c3b6", size = 15043571, upload-time = "2026-05-18T20:42:16.664Z" },
 ]
 
 [[package]]
@@ -271,7 +347,7 @@ wheels = [
 
 [[package]]
 name = "cfn-lint"
-version = "1.50.1"
+version = "1.51.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aws-sam-translator" },
@@ -282,9 +358,9 @@ dependencies = [
     { name = "sympy" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/32/4a76cf04726f363fc213512a5e1d685ffe63c81e9a517f63ef23c1c30dd5/cfn_lint-1.50.1.tar.gz", hash = "sha256:10df565e9774e41c4a5a1b6dca7d09765cd534bdf22dc24add5e4ad1e118699a", size = 4076509, upload-time = "2026-04-29T17:18:34.863Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/ea/bc4954dcbff3ecb500e2593e4b64d0e9a552973249b2a27dd22eee3fb5b0/cfn_lint-1.51.0.tar.gz", hash = "sha256:05d2a59708c99363afe3af6ac7325de95a5b37f8eef7728f41ae567d088a61f1", size = 4088652, upload-time = "2026-05-12T20:34:25.712Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/3c/d2e9d3d7df61d7fcc8bbe1be30794a842d8b20aefdfec2f5b7f7e5c25eec/cfn_lint-1.50.1-py3-none-any.whl", hash = "sha256:e70aa46707a04acf0b557780bbd77984c271bb5651217c9551ad1a77c073b200", size = 6051385, upload-time = "2026-04-29T17:18:32.311Z" },
+    { url = "https://files.pythonhosted.org/packages/48/12/016d6b4a43bb7eb2e430770e04325ef159d73d4183dce94c6fa6dc144902/cfn_lint-1.51.0-py3-none-any.whl", hash = "sha256:116d4f9c7c7d039e69c01c31fe9ff309ff79f0884c859ea92b353507903dd89e", size = 6065464, upload-time = "2026-05-12T20:34:22.885Z" },
 ]
 
 [[package]]
@@ -314,14 +390,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.3"
+version = "8.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz", hash = "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973", size = 350843, upload-time = "2026-05-17T00:47:58.425Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl", hash = "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81", size = 116147, upload-time = "2026-05-17T00:47:56.842Z" },
 ]
 
 [[package]]
@@ -428,11 +504,11 @@ wheels = [
 
 [[package]]
 name = "decorator"
-version = "5.2.1"
+version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/8b/32f9823da46cde7df2087faa08cd98d01b908f8dcab982cdba9c84e85355/decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82", size = 58084, upload-time = "2026-05-18T06:03:28.057Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c", size = 10365, upload-time = "2026-05-18T06:03:26.517Z" },
 ]
 
 [[package]]
@@ -475,6 +551,7 @@ dependencies = [
     { name = "boto3" },
     { name = "boto3-stubs", extra = ["essential", "ses"] },
     { name = "click" },
+    { name = "dspace-rest-client" },
     { name = "jinja2" },
     { name = "jsonschema" },
     { name = "lxml" },
@@ -506,6 +583,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.30" },
     { name = "boto3-stubs", extras = ["essential", "ses"], specifier = ">=1.42.30" },
     { name = "click", specifier = ">=8.3.1" },
+    { name = "dspace-rest-client", specifier = ">=0.1.17" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "lxml", specifier = ">=6.0.2" },
@@ -530,6 +608,21 @@ dev = [
     { name = "ruff", specifier = ">=0.14.13" },
     { name = "types-jsonschema", specifier = ">=4.26.0.20260109" },
     { name = "types-requests", specifier = ">=2.33.0.20260327" },
+]
+
+[[package]]
+name = "dspace-rest-client"
+version = "0.1.17"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pysocks" },
+    { name = "pysolr" },
+    { name = "requests" },
+    { name = "smart-open", extra = ["all"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2b/d23dc1619e223c8992a661654222a9f318ce08020c56b216160bbb12173f/dspace_rest_client-0.1.17.tar.gz", hash = "sha256:6a4e91fdaab415a203a2450e7894c258e64fbbc9db128128c9f164528b9a2a46", size = 32393, upload-time = "2026-03-03T04:25:26.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/92/1c2c3cef024a288b4375da0d49761b8468c6def1a1fc814b133312621e48/dspace_rest_client-0.1.17-py3-none-any.whl", hash = "sha256:fdfbd25058f476225ff9e28c835a731b4787d916db429ae366c16a88eaa57028", size = 23882, upload-time = "2026-03-03T04:25:25.043Z" },
 ]
 
 [[package]]
@@ -593,6 +686,102 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.30.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.53.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ad/ff781329bbbdc0974a098d996e89c9e1f7024262f9e3eec442fbb9ad1ac6/google_auth-2.53.0.tar.gz", hash = "sha256:e7e6aa16f6bee7b2b264830fd04f08087a1d5a836df516251a5d15327b246c9c", size = 335844, upload-time = "2026-05-15T20:53:07.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/dd/1eef226e470369b26824a505c34482c0b493bc35fe8e0c6b003b5feca21a/google_cloud_core-2.6.0.tar.gz", hash = "sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83", size = 36001, upload-time = "2026-05-07T08:04:04.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl", hash = "sha256:6d63ac8e5eca6d9e4319d0a1e2265fadcd7f1049904378caecfa01cf52dd869e", size = 29390, upload-time = "2026-05-07T08:02:34.672Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "3.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/47/205eb8e9a1739b5345843e5a425775cbdc472cc38e7eda082ba5b8d02450/google_cloud_storage-3.10.1.tar.gz", hash = "sha256:97db9aa4460727982040edd2bd13ff3d5e2260b5331ad22895802da1fc2a5286", size = 17309950, upload-time = "2026-03-23T09:35:23.409Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/ff/ca9ab2417fa913d75aae38bf40bf856bb2749a604b2e0f701b37cfcd23cc/google_cloud_storage-3.10.1-py3-none-any.whl", hash = "sha256:a72f656759b7b99bda700f901adcb3425a828d4a29f911bc26b3ea79c5b1217f", size = 324453, upload-time = "2026-03-23T09:35:21.368Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/4b/0b235beccc310d0a48adbc7246b719d173cca6c88c572dfa4b090e39143c/google_resumable_media-2.9.0.tar.gz", hash = "sha256:f7cfb224846a9dd444d125115dfbe8ef02a2b893e78f087762fe716a255a734b", size = 2164534, upload-time = "2026-05-07T08:04:44.236Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/73/3518e63deb1667c5409a4579e28daf5e84479a87a72c547e0487f7883dcd/google_resumable_media-2.9.0-py3-none-any.whl", hash = "sha256:c8901e88e389af8bed64d9696c74d8bad961865eb2236e13e0bfca9bb0a65ca3", size = 81507, upload-time = "2026-05-07T08:03:23.809Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
 name = "graphql-core"
 version = "3.2.8"
 source = { registry = "https://pypi.org/simple" }
@@ -612,11 +801,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.14"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/b1/efac073e0c297ecf2fb33c346989a529d4e19164f1759102dee5953ee17e/idna-3.14.tar.gz", hash = "sha256:466d810d7a2cc1022bea9b037c39728d51ae7dad40d480fc9b7d7ecf98ba8ee3", size = 198272, upload-time = "2026-05-10T20:32:15.935Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/3c/3f62dee257eb3d6b2c1ef2a09d36d9793c7111156a73b5654d2c2305e5ce/idna-3.14-py3-none-any.whl", hash = "sha256:e677eaf072e290f7b725f9acf0b3a2bd55f9fd6f7c70abe5f0e34823d0accf69", size = 72184, upload-time = "2026-05-10T20:32:14.295Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -626,6 +815,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "invoke"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/227c48c5fe47fa178ccf1fda8f047d16c97ba926567b661e9ce2045c600c/invoke-3.0.3.tar.gz", hash = "sha256:437b6a622223824380bfb4e64f612711a6b648c795f565efc8625af66fb57f0c", size = 343419, upload-time = "2026-04-07T15:17:48.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/de/bbc12563bbf979618d17625a4e753ff7a078523e28d870d3626daa97261a/invoke-3.0.3-py3-none-any.whl", hash = "sha256:f11327165e5cbb89b2ad1d88d3292b5113332c43b8553b494da435d6ec6f5053", size = 160958, upload-time = "2026-04-07T15:17:46.875Z" },
 ]
 
 [[package]]
@@ -660,6 +858,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
 ]
 
 [[package]]
@@ -836,28 +1043,27 @@ wheels = [
 
 [[package]]
 name = "lxml"
-version = "6.1.0"
+version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13", size = 4197006, upload-time = "2026-04-18T04:32:51.613Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/d4/9326838b59dc36dfae42eec9656b97520f9997eee1de47b8316aaeed169c/lxml-6.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d2f17a16cd8751e8eb233a7e41aecdf8e511712e00088bf9be455f604cd0d28d", size = 8570663, upload-time = "2026-04-18T04:27:48.253Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/a4/053745ce1f8303ccbb788b86c0db3a91b973675cefc42566a188637b7c40/lxml-6.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0cea5b1d3e6e77d71bd2b9972eb2446221a69dc52bb0b9c3c6f6e5700592d93", size = 4624024, upload-time = "2026-04-18T04:27:52.594Z" },
-    { url = "https://files.pythonhosted.org/packages/90/97/a517944b20f8fd0932ad2109482bee4e29fe721416387a363306667941f6/lxml-6.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc46da94826188ed45cb53bd8e3fc076ae22675aea2087843d4735627f867c6d", size = 4930895, upload-time = "2026-04-18T04:32:56.29Z" },
-    { url = "https://files.pythonhosted.org/packages/94/7c/e08a970727d556caa040a44773c7b7e3ad0f0d73dedc863543e9a8b931f2/lxml-6.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9147d8e386ec3b82c3b15d88927f734f565b0aaadef7def562b853adca45784a", size = 5093820, upload-time = "2026-04-18T04:32:58.94Z" },
-    { url = "https://files.pythonhosted.org/packages/88/ee/2a5c2aa2c32016a226ca25d3e1056a8102ea6e1fe308bf50213586635400/lxml-6.1.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5715e0e28736a070f3f34a7ccc09e2fdcba0e3060abbcf61a1a5718ff6d6b105", size = 5005790, upload-time = "2026-04-18T04:33:01.272Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/38/a0db9be8f38ad6043ab9429487c128dd1d30f07956ef43040402f8da49e8/lxml-6.1.0-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4937460dc5df0cdd2f06a86c285c28afda06aefa3af949f9477d3e8df430c485", size = 5630827, upload-time = "2026-04-18T04:33:04.036Z" },
-    { url = "https://files.pythonhosted.org/packages/31/ba/3c13d3fc24b7cacf675f808a3a1baabf43a30d0cd24c98f94548e9aa58eb/lxml-6.1.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bc783ee3147e60a25aa0445ea82b3e8aabb83b240f2b95d32cb75587ff781814", size = 5240445, upload-time = "2026-04-18T04:33:06.87Z" },
-    { url = "https://files.pythonhosted.org/packages/55/ba/eeef4ccba09b2212fe239f46c1692a98db1878e0872ae320756488878a94/lxml-6.1.0-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:40d9189f80075f2e1f88db21ef815a2b17b28adf8e50aaf5c789bfe737027f32", size = 5350121, upload-time = "2026-04-18T04:33:09.365Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/01/1da87c7b587c38d0cbe77a01aae3b9c1c49ed47d76918ef3db8fc151b1ca/lxml-6.1.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:05b9b8787e35bec69e68daf4952b2e6dfcfb0db7ecf1a06f8cdfbbac4eb71aad", size = 4694949, upload-time = "2026-04-18T04:33:11.628Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/88/7db0fe66d5aaf128443ee1623dec3db1576f3e4c17751ec0ef5866468590/lxml-6.1.0-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0f0f08beb0182e3e9a86fae124b3c47a7b41b7b69b225e1377db983802404e54", size = 5243901, upload-time = "2026-04-18T04:33:13.95Z" },
-    { url = "https://files.pythonhosted.org/packages/00/a8/1346726af7d1f6fca1f11223ba34001462b0a3660416986d37641708d57c/lxml-6.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73becf6d8c81d4c76b1014dbd3584cb26d904492dcf73ca85dc8bff08dcd6d2d", size = 5048054, upload-time = "2026-04-18T04:33:16.965Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/b7/85057012f035d1a0c87e02f8c723ca3c3e6e0728bcf4cb62080b21b1c1e3/lxml-6.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1ae225f66e5938f4fa29d37e009a3bb3b13032ac57eb4eb42afa44f6e4054e69", size = 4777324, upload-time = "2026-04-18T04:33:19.832Z" },
-    { url = "https://files.pythonhosted.org/packages/75/6c/ad2f94a91073ef570f33718040e8e160d5fb93331cf1ab3ca1323f939e2d/lxml-6.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:690022c7fae793b0489aa68a658822cea83e0d5933781811cabbf5ea3bcfe73d", size = 5645702, upload-time = "2026-04-18T04:33:22.436Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/89/0bb6c0bd549c19004c60eea9dc554dd78fd647b72314ef25d460e0d208c6/lxml-6.1.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:63aeafc26aac0be8aff14af7871249e87ea1319be92090bfd632ec68e03b16a5", size = 5232901, upload-time = "2026-04-18T04:33:26.21Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/d9/d609a11fb567da9399f525193e2b49847b5a409cdebe737f06a8b7126bdc/lxml-6.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:264c605ab9c0e4aa1a679636f4582c4d3313700009fac3ec9c3412ed0d8f3e1d", size = 5261333, upload-time = "2026-04-18T04:33:28.984Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/3a/ac3f99ec8ac93089e7dd556f279e0d14c24de0a74a507e143a2e4b496e7c/lxml-6.1.0-cp312-cp312-win32.whl", hash = "sha256:56971379bc5ee8037c5a0f09fa88f66cdb7d37c3e38af3e45cf539f41131ac1f", size = 3596289, upload-time = "2026-04-18T04:27:42.819Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/a7/0a915557538593cb1bbeedcd40e13c7a261822c26fecbbdb71dad0c2f540/lxml-6.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:bba078de0031c219e5dd06cf3e6bf8fb8e6e64a77819b358f53bb132e3e03366", size = 3997059, upload-time = "2026-04-18T04:27:46.764Z" },
-    { url = "https://files.pythonhosted.org/packages/92/96/a5dc078cf0126fbfbc35611d77ecd5da80054b5893e28fb213a5613b9e1d/lxml-6.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:c3592631e652afa34999a088f98ba7dfc7d6aff0d535c410bea77a71743f3819", size = 3659552, upload-time = "2026-04-18T04:27:51.133Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:104c09bda8d2a562824c0e319d0768ce26a779b7601e0931d33b09b53c392ef7", size = 8570821, upload-time = "2026-05-18T19:17:42.068Z" },
+    { url = "https://files.pythonhosted.org/packages/22/00/ff3009c88e65de8011630acf8ab5a09cb2becd2aaf47fba2f3449f6224e9/lxml-6.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c6997a9a534e016695a0ba06b2f07945de682731ff01065b6d5a4474179da1", size = 4624252, upload-time = "2026-05-18T19:17:47.897Z" },
+    { url = "https://files.pythonhosted.org/packages/42/95/bb63f0fd62e554fe078e1fb3c8fe9083c14ddc7ad7fa178d10e57e071ac7/lxml-6.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c921ba5c51e4e9f63b8b00267d06566e1f63407408a0496da2d1d0bfc819c7fc", size = 4930746, upload-time = "2026-05-18T19:18:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/99/0013e8d9b5960f4f041cf0b73e2f80c23eb5205b1f7bfb20203243651359/lxml-6.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:54a7f95e4de5fb94e2f9f4b9055c6ba33bf3d628fd77a1d647c5923caa2cdcdc", size = 5093723, upload-time = "2026-05-18T19:18:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/29/91/317b332636bfc7bddcff828d41b3307f50043f4b237e40849c333d80fa1a/lxml-6.1.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f2ec43df44b1f76249ee0a615334f9b5b060e1c8bd90e706dad2d14d02f383", size = 5005557, upload-time = "2026-05-18T19:18:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2f/cc9bf06afe70f9c9093ae60855d9759da9db601ec4080f7473319666ffd7/lxml-6.1.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:70ef8a7e102a1508f8121aae5b0867abd663f72c14f0a9c937e6554cb4587b7b", size = 5631036, upload-time = "2026-05-18T19:18:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ebe6af670449830d6d9b752c256a983291c766a1365ba5d5460048f9e33a7818", size = 5240367, upload-time = "2026-05-18T19:18:49.217Z" },
+    { url = "https://files.pythonhosted.org/packages/78/83/8555d40948b09ce86f1bd0c68a7ac31d07b1929f92cc1b074006c97ef2d2/lxml-6.1.1-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:27acc820660aaffa4f7c087f29120e12980f7779d56d8492d263170111284740", size = 5350171, upload-time = "2026-05-18T19:18:52.779Z" },
+    { url = "https://files.pythonhosted.org/packages/63/75/5d92da93729b7bad783689e6496049fa40927b45bec7bf183c981de3ca70/lxml-6.1.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:1db753c9115ec7100d073b744d17e25e88a8f90f5c39b2f5dd878149af59671f", size = 4694874, upload-time = "2026-05-18T19:18:55.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/3aad415a9a25b822e783f15deeb4dffccf5113030f1afa2222dd929313d9/lxml-6.1.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4f469aebd783bb741c2ecb2a681008fd26bfe5c16a9a72ed5467f834e810df2", size = 5244492, upload-time = "2026-05-18T19:19:01.28Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a1/5fcf7eb9904b80086aa47dcf0027de07b1bb990afad2e6823144c368ae04/lxml-6.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:766b010012d59470072c1816b5b6c69f1d243e5db36ea5968e94accf430a4635", size = 5048232, upload-time = "2026-05-18T19:18:12.67Z" },
+    { url = "https://files.pythonhosted.org/packages/77/74/1f601b63c7a69fcdf10fa9b148c81da8442204194f6c55509cc485c786b9/lxml-6.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b8d812c6011c08b8111a15e54dd990b8923692d80adf35488bee34026c35accf", size = 4777023, upload-time = "2026-05-18T19:18:15.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b9/7a78f51aec95b1bf780d78e12705a9f6533284f8693dc5c0e6724fa53d3f/lxml-6.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fe0306bd29505a9177aac19f1877174b0e7422c222a59f70b2cd41633448c3dc", size = 5645773, upload-time = "2026-05-18T19:18:23.223Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/98a7b7ad54e4e74fa1f20fff776913980619d0ebe5558232d7da6580bdd8/lxml-6.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5ba186ad207446c65d3bb3d3e0412b032b1d9f595e59861e2354798c5703d955", size = 5233088, upload-time = "2026-05-18T19:18:31.433Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d1/bc0ed2427bf609f2ee10da303a6a226f9c8bce94f945dc29a32ce55de6e4/lxml-6.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa366a1e55b8ebfe8ca8ddc3cfe75c8ebade181aeb0f661d0cb05986b647f72a", size = 5260995, upload-time = "2026-05-18T19:18:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8b/6772e1a4b513fc50a8d931f19edde0e13ae6918510a1e13ff67864f3e5ed/lxml-6.1.1-cp312-cp312-win32.whl", hash = "sha256:126c93f7f56f0eda92f6d8c619edc463a4f23d9252f1c9d0405a76f25fa9f11a", size = 3596382, upload-time = "2026-05-18T19:17:18.37Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/89/45198e9624762af2dfd2cb8782598477ceb29f6e59caab560388ae1f4ec1/lxml-6.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:26e6eda8d38c1fcab1090dd196ee87cbd13788e531937610e2589085de074e77", size = 3997255, upload-time = "2026-05-18T19:17:56.781Z" },
 ]
 
 [[package]]
@@ -1017,11 +1223,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-ec2"
-version = "1.43.6"
+version = "1.43.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/c5/ef174f9ff1e5d2aca242184d0129d69f73f7a5753ffa5dc2a028f684a368/mypy_boto3_ec2-1.43.6.tar.gz", hash = "sha256:cd856ee6d746436a098c267fffcc7e0d9a300bfadda6fc3bbe9422662c697af5", size = 445260, upload-time = "2026-05-07T21:15:21.963Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/f7/1ef1d89fb66715514a1b4e5a8e2a06b5587fcecd0ddda757c8a1c445241d/mypy_boto3_ec2-1.43.10.tar.gz", hash = "sha256:7ee2d361ccf5a0d1a037cce84cd27c40f91dbf4265e5f8e6a6eb51b98f6cbe8f", size = 445858, upload-time = "2026-05-18T20:46:41.141Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/e4/8419998f500d4db474e3b7523709f5b44e3ef9163a6989e36a28b15ff41d/mypy_boto3_ec2-1.43.6-py3-none-any.whl", hash = "sha256:b57e19331177c3ca802b0a2879af22d008b52b176376ef48f45dc3a6f2944b27", size = 434213, upload-time = "2026-05-07T21:15:19.201Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/f4/6b12ffb91a2001d626ae0c61af5c55c4121d391e6460911ff147e5d8a7fb/mypy_boto3_ec2-1.43.10-py3-none-any.whl", hash = "sha256:622b7d83e4d6af7363bdbe486cc9049086a6407d77c16e1c82165c68c6d391ce", size = 434794, upload-time = "2026-05-18T20:46:37.276Z" },
 ]
 
 [[package]]
@@ -1098,21 +1304,21 @@ wheels = [
 
 [[package]]
 name = "numpy"
-version = "2.4.4"
+version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573, upload-time = "2026-03-29T13:18:52.629Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782, upload-time = "2026-03-29T13:18:55.579Z" },
-    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038, upload-time = "2026-03-29T13:18:57.769Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666, upload-time = "2026-03-29T13:19:00.341Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480, upload-time = "2026-03-29T13:19:03.63Z" },
-    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036, upload-time = "2026-03-29T13:19:07.428Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643, upload-time = "2026-03-29T13:19:10.775Z" },
-    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117, upload-time = "2026-03-29T13:19:13.464Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584, upload-time = "2026-03-29T13:19:16.155Z" },
-    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450, upload-time = "2026-03-29T13:19:18.994Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
 ]
 
 [[package]]
@@ -1198,6 +1404,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/27/1d/297ff2c7ea50a768a2247621d6451abb2a07c0e9be7ca6d36ebe371658e5/pandas_stubs-3.0.0.260204.tar.gz", hash = "sha256:bf9294b76352effcffa9cb85edf0bed1339a7ec0c30b8e1ac3d66b4228f1fbc3", size = 109383, upload-time = "2026-02-04T15:17:17.247Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/2f/f91e4eee21585ff548e83358332d5632ee49f6b2dcd96cb5dca4e0468951/pandas_stubs-3.0.0.260204-py3-none-any.whl", hash = "sha256:5ab9e4d55a6e2752e9720828564af40d48c4f709e6a2c69b743014a6fcb6c241", size = 168540, upload-time = "2026-02-04T15:17:15.615Z" },
+]
+
+[[package]]
+name = "paramiko"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bcrypt" },
+    { name = "cryptography" },
+    { name = "invoke" },
+    { name = "pynacl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/93/dcc25d52f49022ae6175d15e6bd751f1acc99b98bc61fc55e5155a7be2e7/paramiko-5.0.0.tar.gz", hash = "sha256:36763b5b95c2a0dcfdf1abc48e48156ee425b21efe2f0e787c2dd5a95c0e5e79", size = 1548586, upload-time = "2026-05-09T18:28:52.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/5b/eadf6d45de38d30ab603f49393b6cd2cbe7e233af8cf90197e32782b68a9/paramiko-5.0.0-py3-none-any.whl", hash = "sha256:b7044611c30140d9a75261653210e2002977b71a0497ff3ba0d98d7edbf62f7c", size = 208919, upload-time = "2026-05-09T18:28:50.295Z" },
 ]
 
 [[package]]
@@ -1341,6 +1562,33 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/56/e647b0c675392d2da368da7b6f158f7368b18542fd6f7d7400a2f39de000/proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9", size = 57221, upload-time = "2026-05-07T08:04:50.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl", hash = "sha256:a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8", size = 50410, upload-time = "2026-05-07T08:03:31.962Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
+    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
+]
+
+[[package]]
 name = "psutil"
 version = "7.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1393,6 +1641,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1472,6 +1741,29 @@ wheels = [
 ]
 
 [[package]]
+name = "pynacl"
+version = "1.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465", size = 388458, upload-time = "2026-01-01T17:32:16.829Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020, upload-time = "2026-01-01T17:32:18.34Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174, upload-time = "2026-01-01T17:32:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085, upload-time = "2026-01-01T17:32:22.24Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614, upload-time = "2026-01-01T17:32:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251, upload-time = "2026-01-01T17:32:25.69Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
+    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
+    { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
+]
+
+[[package]]
 name = "pynamodb"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1491,6 +1783,25 @@ sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
+
+[[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
+
+[[package]]
+name = "pysolr"
+version = "3.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/2a/b6c793a17e173524ccc7a90cdd8ebb65264f6ebcdb1942eba2478ec3a85e/pysolr-3.11.0.tar.gz", hash = "sha256:bbd0e7467835316880f994b55386c9bc3c146733c17d85a3fed317755976c40a", size = 63983, upload-time = "2025-11-18T10:42:40.247Z" }
 
 [[package]]
 name = "pytest"
@@ -1522,15 +1833,15 @@ wheels = [
 
 [[package]]
 name = "python-discovery"
-version = "1.3.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/e0/cc5a8653e9a24f6cf84768f05064aa8ed5a83dcefd5e2a043db14a1c5f44/python_discovery-1.3.0.tar.gz", hash = "sha256:d098f1e86be5d45fe4d14bf1029294aabbd332f4321179dec85e76cddce834b0", size = 63925, upload-time = "2026-05-05T14:38:39.769Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/60/e88788207d81e46362cfbef0d4aaf4c0f49efc3c12d4c3fa3f542c34ebec/python_discovery-1.3.1.tar.gz", hash = "sha256:62f6db28064c9613e7ca76cb3f00c38c839a07c31c00dfe7ed0986493d2150a6", size = 68011, upload-time = "2026-05-12T20:53:36.336Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/d4/24d543ab8b8158b7f5a97113c831205f5c900c92c8762b1e7f44b7ea0405/python_discovery-1.3.0-py3-none-any.whl", hash = "sha256:441d9ced3dfce36e113beb35ca302c71c7ef06f3c0f9c227a0b9bb3bd49b9e9f", size = 33124, upload-time = "2026-05-05T14:38:38.539Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/6f/a05a317a66fee0aad270011461f1a63a453ed12471249f172f7d2e2bc7b4/python_discovery-1.3.1-py3-none-any.whl", hash = "sha256:ed188687ebb3b82c01a17cd5ac62fc94d9f6487a7f1a0f9dfe89753fec91039c", size = 33185, upload-time = "2026-05-12T20:53:34.969Z" },
 ]
 
 [[package]]
@@ -1624,7 +1935,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.34.0"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1632,9 +1943,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/b8/7a707d60fea4c49094e40262cc0e2ca6c768cca21587e34d3f705afec47e/requests-2.34.0.tar.gz", hash = "sha256:7d62fe92f50eb82c529b0916bb445afa1531a566fc8f35ffdc64446e771b856a", size = 142436, upload-time = "2026-05-11T19:29:51.717Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/e6/e300fce5fe83c30520607a015dabd985df3251e188d234bfe9492e17a389/requests-2.34.0-py3-none-any.whl", hash = "sha256:917520a21b767485ce7c588f4ebb917c436b24a31231b44228715eaeb5a52c60", size = 73021, upload-time = "2026-05-11T19:29:49.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -1701,27 +2012,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.12"
+version = "0.15.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/21/a7d5c126d5b557715ef81098f3db2fe20f622a039ff2e626af28d674ab80/ruff-0.15.13.tar.gz", hash = "sha256:f9d89f17f7ba7fb2ed42921f0df75da797a9a5d71bc39049e2c687cf2baf44b7", size = 4678180, upload-time = "2026-05-14T13:44:37.869Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
-    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
-    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
-    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
-    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
-    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
-    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
-    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
-    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/61/11d458dc6ac22504fd8e237b29dfd40504c7fbbcc8930402cfe51a8e63ed/ruff-0.15.13-py3-none-linux_armv6l.whl", hash = "sha256:444b580fc72fd6887e650acd3e575e18cdc79dbcf42fb4030b491057921f61f8", size = 10738279, upload-time = "2026-05-14T13:44:18.7Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ca/caa871ee7be718c45256fada4e16a218ee3e33f0c4a46b729a60a24912e6/ruff-0.15.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6590d009e7cb7ebf36f83dbdd44a3fa48a0994ff6f1cdc1b08006abe58f98dc7", size = 11124798, upload-time = "2026-05-14T13:44:06.427Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/19/43f5f2e568dddde567fc41f8471f9432c09563e19d3e617a48cfa52f8f0a/ruff-0.15.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1c26d2f66163deeb6e08d8b39fbbe983ce3c71cea06a6d7591cfd1421793c629", size = 10460761, upload-time = "2026-05-14T13:44:04.375Z" },
+    { url = "https://files.pythonhosted.org/packages/99/df/cf938cd6de3003178f03ad7c1ea2a6c099468c03a35037985070b37e76be/ruff-0.15.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbd6f94b434f896308e4d57fb7bfde0d02b99f7a64b3bdab0fdfa6a864203a5", size = 10804451, upload-time = "2026-05-14T13:44:25.221Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7d/5d0973129b154ded2225729169d7068f26b467760b146493fde138415f23/ruff-0.15.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3259f3be4d181bda591da5db2571aed6853c6a048157756448020bc6c5cd22", size = 10534285, upload-time = "2026-05-14T13:44:08.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e3/6b999bbc66cd51e5f073842bc2a3995e99c5e0e72e16b15e7261f7abf57a/ruff-0.15.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae9c17e5eb4430c154e76abc25d79a318190f5a997f38fb6b114416c5319ffc9", size = 11312063, upload-time = "2026-05-14T13:44:11.274Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5a/642639e9f5db04f1e97fbd6e091c6fd20725bdf072fb114d00eefb9e6eb8/ruff-0.15.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e2e39bff6c341f4b577a21b801326fab0b11847f48fcaa83f00a113c9b3cb55", size = 12183079, upload-time = "2026-05-14T13:44:01.634Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4c/7585735f6b53b0f12de13618b2f7d250a844f018822efc899df2e7b8295f/ruff-0.15.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e8d9a8e08013542e94d3220bc5b62cc3e5ef87c5f74bff367d3fac14fab013e6", size = 11440833, upload-time = "2026-05-14T13:43:59.043Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/31/bf1a0803d077e679cfeee5f2f67290a0fa79c7385b5d9a8c17b9db2c48f0/ruff-0.15.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc411dfebe5eebe55ce041c6ae080eb7668955e866daa2fbb16692a784f1c4ca", size = 11434486, upload-time = "2026-05-14T13:44:27.761Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/4e/62c9b999875d4f14db80f277c030578f5e249c9852d65b7ac7ad0b43c041/ruff-0.15.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:768494eb08b9cee54e2fd27969966f74db5a57f6eaa7a90fcb3306af34dfc4bd", size = 11385189, upload-time = "2026-05-14T13:44:13.704Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/89/7e959047a104df3eb12863447c110140191fc5b6c4f379ea2e803fcdb0e4/ruff-0.15.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fb75f9a3a7e42ffe117d734494e6c5e5cb3565d66e12612cb63d0e572a41a5b6", size = 10781380, upload-time = "2026-05-14T13:43:56.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/52/5fd18f3b88cab63e88aa11516b3b4e1e5f720e5c330f8dbe5c26210f41f8/ruff-0.15.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8cb74dd33bb2f6613faf7fc03b660053b5ac4f80e706d5788c6335e2a8048d51", size = 10540605, upload-time = "2026-05-14T13:44:20.748Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e0/9e35f338990d3e41a82875ff7053ffe97541dae81c9d02143177f381d572/ruff-0.15.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7ef823f817fcd191dc934e984be9cf4094f808effa16f2542ad8e821ba02bbf2", size = 11036554, upload-time = "2026-05-14T13:44:16.256Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/13/070fb048c24080fba188f66371e2a92785be257ad02242066dc7255ac6e9/ruff-0.15.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f345a13937bd7f09f6f5d19fa0721b0c103e00e7f62bc67089a8e5e037719e0b", size = 11528133, upload-time = "2026-05-14T13:44:22.808Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8c/b1e1666aef7fc6555094d73ae6cd981701781ae85b97ceefc0eebd0b4668/ruff-0.15.13-py3-none-win32.whl", hash = "sha256:4044f94208b3b05ba0fc4a4abd0558cf4d6459bd18325eead7fd8cc66f909b41", size = 10721455, upload-time = "2026-05-14T13:44:35.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a6/870a3e8a50590bb92be184ad928c2922f088b00d9dc5c5ec7b924ee08c22/ruff-0.15.13-py3-none-win_amd64.whl", hash = "sha256:7064884d442b7d477b4e7473d12da7f08851d2b1982763c5d3f388a19468a1a4", size = 11900409, upload-time = "2026-05-14T13:44:30.389Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/36/9c015cd052fca743dae8cb2aeb16b551444787467db42ceab0fc968865af/ruff-0.15.13-py3-none-win_arm64.whl", hash = "sha256:2471da9bd1068c8c064b5fd9c0c4b6dddffd6369cb1cd68b29993b1709ff1b21", size = 11179336, upload-time = "2026-05-14T13:44:33.026Z" },
 ]
 
 [[package]]
@@ -1738,15 +2049,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.59.0"
+version = "2.60.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/e0/9bf5e5fc7442b10880f3ec0eff0ef4208b84a099606f343ec4f5445227fb/sentry_sdk-2.59.0.tar.gz", hash = "sha256:cd265808ef8bf3f3edf69b527c0a0b2b6b1322762679e55b8987db2e9584aec1", size = 447331, upload-time = "2026-05-04T12:19:06.538Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/a2/2e6c090db384cc515069f4f85542bd5baf6786852073020ea73d4a76d3ea/sentry_sdk-2.60.0.tar.gz", hash = "sha256:0bd25e54e78ca02d0be512529fa644bbbf9e8470d7b26371294012d4ca93c978", size = 452946, upload-time = "2026-05-13T13:34:52.516Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/00/b8cc413748fb6383d1582e7cda51314f99743351c462a92dc690d5b5853b/sentry_sdk-2.59.0-py2.py3-none-any.whl", hash = "sha256:abcf65ee9a9d9cdebf9ad369782408ecca9c1c792686ef06ba34f5ab233527fe", size = 468432, upload-time = "2026-05-04T12:19:04.741Z" },
+    { url = "https://files.pythonhosted.org/packages/29/41/f2b800b7f12a05dd48c2a6280d4dd812d1425fc66ed3fe3fd99420c41d1a/sentry_sdk-2.60.0-py3-none-any.whl", hash = "sha256:28a536c03291c8bcb363cf35c611b32738ec118ff64d8d6383b096448ac4c803", size = 475616, upload-time = "2026-05-13T13:34:50.259Z" },
 ]
 
 [[package]]
@@ -1778,14 +2089,26 @@ wheels = [
 
 [[package]]
 name = "smart-open"
-version = "7.6.1"
+version = "7.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/65/3ada667d32675399001bf022ad3d9f3989b57101351ebc71d6fbe2384634/smart_open-7.6.1.tar.gz", hash = "sha256:4347996e7ba21db7cd1e059632e0b30395407e4f6c660d2ddffc8f2a9ae5f990", size = 54754, upload-time = "2026-05-09T06:23:37.06Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/d8/1481294b2d110b805c0f5d23ef34158b7d5d4283633c0d34c69ea89bb76b/smart_open-7.0.5.tar.gz", hash = "sha256:d3672003b1dbc85e2013e4983b88eb9a5ccfd389b0d4e5015f39a9ee5620ec18", size = 71693, upload-time = "2024-10-04T13:58:32.442Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/78/0f68b93564b8c6b6987a0696c582ba2591a381ab2f733a501909e949f241/smart_open-7.6.1-py3-none-any.whl", hash = "sha256:b4de6aebef023aca91cc9fb372052e1343ba3f152de215bd22391a663e3ddd21", size = 64845, upload-time = "2026-05-09T06:23:35.386Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bc/706838af28a542458bffe74a5d0772ca7f207b5495cd9fccfce61ef71f2a/smart_open-7.0.5-py3-none-any.whl", hash = "sha256:8523ed805c12dff3eaa50e9c903a6cb0ae78800626631c5fe7ea073439847b89", size = 61387, upload-time = "2024-10-04T13:58:35.073Z" },
+]
+
+[package.optional-dependencies]
+all = [
+    { name = "azure-common" },
+    { name = "azure-core" },
+    { name = "azure-storage-blob" },
+    { name = "boto3" },
+    { name = "google-cloud-storage" },
+    { name = "paramiko" },
+    { name = "requests" },
+    { name = "zstandard" },
 ]
 
 [[package]]
@@ -1885,26 +2208,26 @@ wheels = [
 
 [[package]]
 name = "types-jsonschema"
-version = "4.26.0.20260508"
+version = "4.26.0.20260518"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "referencing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/d8/7ba8007c48e0de93d82268e0447312c9c28d90ac7a8f73e034356bb40921/types_jsonschema-4.26.0.20260508.tar.gz", hash = "sha256:ae0be85ac6ec0cb94a98f75f876b0620cf2afa3e37fdf8460203f4d05f745acb", size = 16602, upload-time = "2026-05-08T04:51:45.26Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/46/73b6a5d61a61015c4248030a8cb07e5bdddb4041430fae9e585a68692578/types_jsonschema-4.26.0.20260518.tar.gz", hash = "sha256:e1dd53dc97a64f5eccdd6fa9839666e09bb500a8ebba2db6fdaf1789faea81a6", size = 16638, upload-time = "2026-05-18T06:06:44.106Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/55/4f25833c410426b1f359dd579f3b3d1ee0f43f5674b23a815f396d3ea63c/types_jsonschema-4.26.0.20260508-py3-none-any.whl", hash = "sha256:4ec1dea0a757c8c2e2aa7bc085612fb54e1ae9562428d5da6f26dd7a0f24dbc2", size = 16062, upload-time = "2026-05-08T04:51:44.437Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d5/134f8a147dcecda10db7f60cfc6af0578a25a5c53c87b3907a64385e0184/types_jsonschema-4.26.0.20260518-py3-none-any.whl", hash = "sha256:30b30a518c7fe335df85c919fcbcc631b69c03d4a4b5b632fa916bea03065307", size = 16072, upload-time = "2026-05-18T06:06:43.264Z" },
 ]
 
 [[package]]
 name = "types-requests"
-version = "2.33.0.20260508"
+version = "2.33.0.20260518"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/6b/eb226bdd61a982c9a03e02c657fb4ab001733506e6423906ac142331f2e3/types_requests-2.33.0.20260508.tar.gz", hash = "sha256:81b2ae5f0d20967714a6aa5ef9284c05570d7cb06b7de8f2a77b918b63ddd411", size = 23991, upload-time = "2026-05-08T04:50:56.818Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/01/c5a19253fe1ac159159ddf9a3a07cec8bb5e486ec4d9002ad2821da0e5d2/types_requests-2.33.0.20260518.tar.gz", hash = "sha256:df7bd3bfe0ca8402dfb841e7d9be714bb5578203283d66d7dc4ef69343449a5e", size = 24752, upload-time = "2026-05-18T06:07:37.966Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/96/080db0afdf2c5cc5fe512b41354e8d114fe8f65e9510c56ff8dfd40216ce/types_requests-2.33.0.20260508-py3-none-any.whl", hash = "sha256:fa01459cca184229713df03709db46a905325906d27e042cd4fd7ea3d15d3400", size = 20722, upload-time = "2026-05-08T04:50:55.548Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl", hash = "sha256:626d697d1adaaff76e2044dc8c5c051d8f21abc157bdfe204a75558076fe0bf0", size = 21391, upload-time = "2026-05-18T06:07:37.044Z" },
 ]
 
 [[package]]
@@ -1957,7 +2280,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.3.1"
+version = "21.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -1965,9 +2288,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/0d/915c02c94d207b85580eb09bffab54438a709e7288524094fe781da526c2/virtualenv-21.3.1.tar.gz", hash = "sha256:c2305bc1fddeec40699b8370d13f8d431b0701f00ce895061ce493aeded4426b", size = 7613791, upload-time = "2026-05-05T01:34:31.402Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/ba/1f6e8c957e4932be060dcdc482d339c12e0216351478add3645cdaa53c05/virtualenv-21.3.3.tar.gz", hash = "sha256:f5bda277e553b1c2b3c1a8debfc30496e1288cc93ce6b7b71b3280047e317328", size = 7613784, upload-time = "2026-05-13T18:01:30.19Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/4f/f71e641e504111a5a74e3a20bc52d01bd86788b22699dd3fee1c63253cf6/virtualenv-21.3.1-py3-none-any.whl", hash = "sha256:d1a71cf58f2f9228fff23a1f6ec15d39785c6b32e03658d104974247145edd35", size = 7594539, upload-time = "2026-05-05T01:34:28.98Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/34/a9dbe051de88a63eb7408ea66630bac38e72f7f6077d4be58737106860d9/virtualenv-21.3.3-py3-none-any.whl", hash = "sha256:7d5987d8369e098e41406efb780a3d4ca79280097293899e351a6407ee153ab3", size = 7594554, upload-time = "2026-05-13T18:01:27.815Z" },
 ]
 
 [[package]]
@@ -2018,4 +2341,29 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/fc/f26eb6ef91ae723a03e16eddb198abcfce2bc5a42e224d44cc8b6765e57e/zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b", size = 795738, upload-time = "2025-09-14T22:16:56.237Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1c/d920d64b22f8dd028a8b90e2d756e431a5d86194caa78e3819c7bf53b4b3/zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00", size = 640436, upload-time = "2025-09-14T22:16:57.774Z" },
+    { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019, upload-time = "2025-09-14T22:16:59.302Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/15/efef5a2f204a64bdb5571e6161d49f7ef0fffdbca953a615efbec045f60f/zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea", size = 5063012, upload-time = "2025-09-14T22:17:01.156Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/a6ce629ffdb43959e92e87ebdaeebb5ac81c944b6a75c9c47e300f85abdf/zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb", size = 5394148, upload-time = "2025-09-14T22:17:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/79/2bf870b3abeb5c070fe2d670a5a8d1057a8270f125ef7676d29ea900f496/zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a", size = 5451652, upload-time = "2025-09-14T22:17:04.979Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902", size = 5546993, upload-time = "2025-09-14T22:17:06.781Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c7/3483ad9ff0662623f3648479b0380d2de5510abf00990468c286c6b04017/zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f", size = 5046806, upload-time = "2025-09-14T22:17:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/206883dd25b8d1591a1caa44b54c2aad84badccf2f1de9e2d60a446f9a25/zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b", size = 5576659, upload-time = "2025-09-14T22:17:10.164Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/31/76c0779101453e6c117b0ff22565865c54f48f8bd807df2b00c2c404b8e0/zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6", size = 4953933, upload-time = "2025-09-14T22:17:11.857Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e1/97680c664a1bf9a247a280a053d98e251424af51f1b196c6d52f117c9720/zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91", size = 5268008, upload-time = "2025-09-14T22:17:13.627Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/73/316e4010de585ac798e154e88fd81bb16afc5c5cb1a72eeb16dd37e8024a/zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708", size = 5433517, upload-time = "2025-09-14T22:17:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/60/dd0f8cfa8129c5a0ce3ea6b7f70be5b33d2618013a161e1ff26c2b39787c/zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512", size = 5814292, upload-time = "2025-09-14T22:17:17.827Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5f/75aafd4b9d11b5407b641b8e41a57864097663699f23e9ad4dbb91dc6bfe/zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa", size = 5360237, upload-time = "2025-09-14T22:17:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8d/0309daffea4fcac7981021dbf21cdb2e3427a9e76bafbcdbdf5392ff99a4/zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd", size = 436922, upload-time = "2025-09-14T22:17:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3b/fa54d9015f945330510cb5d0b0501e8253c127cca7ebe8ba46a965df18c5/zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01", size = 506276, upload-time = "2025-09-14T22:17:21.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6b/8b51697e5319b1f9ac71087b0af9a40d8a6288ff8025c36486e0c12abcc4/zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9", size = 462679, upload-time = "2025-09-14T22:17:23.147Z" },
 ]


### PR DESCRIPTION
### Purpose and background context

This PR implement batch preparation methods for digitized theses workflow. I went back-and-forth on whether I should send a PR with the entire workflow, but as I saw the changes that were piling up, I decided it would be best to request review in reasonably sized chunks. This also allows us to focus / reflect on the key differences for this workflow for each step of the DSC workflow.

Here are some key points to highlight about the `create` / `prepare_batch` methods for the digitized theses workflow:
1. The workflow has [a `minted_batch_id` attribute](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1626-digitized-theses-workflow-create/dsc/workflows/digitized_theses/workflow.py#L48-L54), which is comprised of the original batch ID and the current date timestamp.
1. [`DigitizedTheses.prepare_batch`](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1626-digitized-theses-workflow-create/dsc/workflows/digitized_theses/workflow.py#L95-L161) does not collect exceptions in the `errors` list like other workflows.
   1. **Why:** This allows DSC to proceed with writing all item submissions to the DynamoDB table, with any exceptions captured via the `ItemSubmission.status_details` field.
      1. When DSC sends the report, the resulting CSV file from DynamoDB will include all intended item submissions in the batch rather than creating a separate `errors.csv`.
       1. No `BatchCreationFailedError` is raised. **TBD when this error should be raised (if ever) for the workflow.**
1. After the `create` step, the minted batch ID is what gets passed in the latter calls to `submit` and `finalize`.
   1. For this reason, I left `DigitizedTheses.batch_path` as is and explicitly used `DigitizedTheses.minted_batch_id` when writing files to S3.
1. Why do we save the Alma metadata in XML files to S3?
   1. When we call `submit`, we can avoid repeated calls to Alma SRU and read the metadata from S3 instead. The saved XML files are also simplified from the original Alma SRU response (the saved file sets the `<record>` as the root of the XML file -- will no longer require [these steps](https://github.com/MITLibraries/dspace-submission-composer/blob/bc86c7713ffa7d014bf9a32034d002d0fb07db22/dsc/workflows/digitized_theses/transformer.py#L144-L146)).
      
### How can a reviewer manually see the effects of these changes?

While the test suite includes [several new unit tests for the simpler functions in `dsc.workflows.DigitizedTheses`](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1626-digitized-theses-workflow-create/tests/workflows/digitized_theses/test_workflow.py), I'm requesting that we move forward with the current set of unit tests **given the additional local testing with MinIO shared below**.

**Note:** In general, DSC has been a complex app to test. Recent changes have relied on actual runs with the DSO Step Function, but this is not possible until we have a test instance of DSpace 8 available. Revisiting the test suite for clean up / improve maintainability is definitely on track for future work! Thanking reviewers in advance for understanding.

### Local testing of `dsc.workflows.DigitizedTheses.prepare_batch`

**About the test data:**
These five files were provided by Sadie (i.e., items that were imported into DSpace via v1 workflow):

* **12854433**: https://hdl.handle.net/1721.1/157046	
* **25395837**: https://hdl.handle.net/1721.1/148716
* **34619573**: https://hdl.handle.net/1721.1/154113
* **22215428**: https://hdl.handle.net/1721.1/158471	
* **05588126**: https://hdl.handle.net/1721.1/157651

An additional file for a student-submitted electronic theses (i.e., should be skipped by workflow) is used for testing:
* **932127295**: http://hdl.handle.net/1721.1/100593

---

1. Created a batch (`batch-0`) in the digitized theses workspace S3 bucket:
<img width="1664" height="533" alt="image" src="https://github.com/user-attachments/assets/4c980f39-2f28-4ca2-b820-e56e38f7fc7e" />

2. After running `dsc.workflows.DigitizedTheses.prepare_batch` in IPython:

- Contents are synced to a minted batch folder **five item submissions** moved to a `replacement-theses/` subfolder and **one item submission** (a student-submitted electronic thesis) remains at unmoved.
<img width="1358" height="229" alt="image" src="https://github.com/user-attachments/assets/fe6eb859-23e6-4168-bd39-e0a90505203e" />

### Includes new or updated dependencies?
YES 

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1626

### Code review
* Code review best practices are documented [here](https://mitlibraries.github.io/guides/collaboration/code_review.html) and you are encouraged to have a constructive dialogue with your reviewers about their preferences and expectations.