### PR TITLE
Digitized theses workflow retrieves item handles for synced replacement theses

### DIFF
--- a/dsc/workflows/digitized_theses/workflow.py
+++ b/dsc/workflows/digitized_theses/workflow.py
@@ -189,19 +189,34 @@ class DigitizedTheses(Workflow):
                 )
                 continue
 
+            # track identifier as 'seen'
             seen_item_identifiers.append(item_identifier)
-            item_submissions.append(
-                ItemSubmission(
-                    batch_id=self.batch_id,
-                    item_identifier=item_identifier,
-                    workflow_name=self.workflow_name,
-                    status=(
-                        ItemSubmissionStatus.CREATE_SUCCESS
-                        if theses_subfolder in ["replacement-theses", "new-theses"]
-                        else ItemSubmissionStatus.CREATE_SKIPPED
-                    ),
-                )
+
+            # create an instance of ItemSubmission
+            item_submission = ItemSubmission(
+                batch_id=self.batch_id,
+                item_identifier=item_identifier,
+                workflow_name=self.workflow_name,
             )
+
+            if theses_subfolder == "replacement-theses":
+                try:
+                    dspace_item = self._get_item_from_dspace(
+                        item_submission.item_identifier
+                    )
+                    item_submission.dspace_handle = dspace_item.handle
+                    item_submission.status = ItemSubmissionStatus.CREATE_SUCCESS
+                    item_submission.status_details = "Replacement thesis"
+                except exceptions.DSpaceClientSearchError as exception:
+                    item_submission.status = ItemSubmissionStatus.CREATE_SKIPPED
+                    item_submission.status_details = str(exception)
+            elif theses_subfolder == "new-theses":
+                item_submission.status = ItemSubmissionStatus.CREATE_SUCCESS
+                item_submission.status_details = "New thesis"
+            else:
+                item_submission.status = ItemSubmissionStatus.CREATE_SKIPPED
+                item_submission.status_details = "Skipped thesis"
+            item_submissions.append(item_submission)
 
         return item_submissions
 
@@ -256,7 +271,7 @@ class DigitizedTheses(Workflow):
                 requests.exceptions.HTTPError,
                 exceptions.ItemMetadataNotFoundError,
             ) as exception:
-                item_submission.status = "create_failed"
+                item_submission.status = ItemSubmissionStatus.CREATE_FAILED
                 item_submission.status_details = str(exception)
                 item_submissions.append(item_submission)
                 continue
@@ -265,7 +280,7 @@ class DigitizedTheses(Workflow):
             try:
                 dspace_item = self._get_item_from_dspace(item_submission.item_identifier)
             except exceptions.DSpaceClientSearchError as exception:
-                item_submission.status = "create_skipped"
+                item_submission.status = ItemSubmissionStatus.CREATE_FAILED
                 item_submission.status_details = str(exception)
                 item_submissions.append(item_submission)
                 continue
@@ -273,20 +288,19 @@ class DigitizedTheses(Workflow):
             # check if item submission is a 'Replacement thesis'
             if dspace_item and not self._is_replacement_thesis(dspace_item):
                 item_submission.dspace_handle = dspace_item.handle
-                item_submission.status = "create_skipped"
+                item_submission.status = ItemSubmissionStatus.CREATE_SKIPPED
                 item_submission.status_details = "Cannot replace the electronic version submitted by the student author."  # noqa: E501
                 item_submissions.append(item_submission)
                 continue
 
             if dspace_item and self._is_replacement_thesis(dspace_item):
                 item_submission.dspace_handle = dspace_item.handle
-                item_submission.status = "create_success"
+                item_submission.status = ItemSubmissionStatus.CREATE_SUCCESS
                 item_submission.status_details = "Replacement thesis"
-                item_submissions.append(item_submission)
             else:
-                item_submission.status = "create_success"
+                item_submission.status = ItemSubmissionStatus.CREATE_SUCCESS
                 item_submission.status_details = "New thesis"
-                item_submissions.append(item_submission)
+            item_submissions.append(item_submission)
 
         self._move_batch_files_to_theses_subfolders(
             item_submissions, batch_location=tmp_batch_path

--- a/tests/workflows/digitized_theses/test_workflow.py
+++ b/tests/workflows/digitized_theses/test_workflow.py
@@ -11,6 +11,7 @@ from freezegun import freeze_time
 from lxml import etree
 
 from dsc import exceptions
+from dsc.db.models import ItemSubmissionStatus
 from dsc.item_submission import ItemSubmission
 from dsc.workflows.digitized_theses import (
     DigitizedTheses,
@@ -110,7 +111,8 @@ def alma_sru_response_no_record():
 
 
 @pytest.fixture
-def mock_s3_digitized_theses(mocked_s3, s3_client):
+def mock_s3_digitized_theses_dsc(mocked_s3, s3_client):
+    """Mock batch for digitized theses in DSC S3 bucket."""
     for source_metadata_file in glob.glob(
         "tests/fixtures/digitized-theses/batch-aaa/**/*.xml", recursive=True
     ):
@@ -169,6 +171,102 @@ def test_workflow_update_batch_id():
     workflow = DigitizedTheses(batch_id="batch-aaa")
 
     assert workflow._update_batch_id(batch_id="batch-aaa") == "batch-aaa-20250101T090000Z"
+
+
+@patch("dsc.workflows.digitized_theses.workflow.DigitizedTheses._get_item_from_dspace")
+def test_workflow_get_item_submissions_from_synced_batch_replacement(
+    mock_workflow_get_item_from_dspace, mock_s3_digitized_theses_dsc
+):
+    """Verify workflow can get item submissions from synced batch.
+
+    This test uses mock_s3_digitized_theses, which represents a previously
+    created batch in the DSC S3 bucket (i.e., contents organized into
+    theses subfolders). This test shows the workflow's ability to
+    generate ItemSubmissions based on the contents of the existing
+    batch in the DSC S3 bucket.
+    """
+    mock_response = MagicMock()
+    mock_response.handle = "1721.1/157651"
+    mock_workflow_get_item_from_dspace.return_value = mock_response
+
+    workflow = DigitizedTheses(batch_id="batch-aaa")
+    results = workflow._get_item_submissions_from_synced_batch()
+
+    assert results == [
+        ItemSubmission(
+            batch_id="batch-aaa",
+            item_identifier="05588126",
+            workflow_name="digitized-theses",
+            dspace_handle="1721.1/157651",
+            status=ItemSubmissionStatus.CREATE_SUCCESS,
+            status_details="Replacement thesis",
+        )
+    ]
+
+
+@patch("dsc.workflows.digitized_theses.workflow.DigitizedTheses._get_item_from_dspace")
+def test_workflow_get_item_submissions_from_synced_batch_replacement_not_found(
+    mock_workflow_get_item_from_dspace,
+    mock_s3_digitized_theses_dsc,
+):
+    mock_workflow_get_item_from_dspace.side_effect = exceptions.DSpaceClientSearchError(
+        "Error occurred"
+    )
+    workflow = DigitizedTheses(batch_id="batch-aaa")
+    results = workflow._get_item_submissions_from_synced_batch()
+
+    assert results == [
+        ItemSubmission(
+            batch_id="batch-aaa",
+            item_identifier="05588126",
+            workflow_name="digitized-theses",
+            dspace_handle=None,
+            status=ItemSubmissionStatus.CREATE_SKIPPED,
+            status_details="Error occurred",
+        )
+    ]
+
+
+@patch("dsc.workflows.digitized_theses.workflow.S3Client.files_iter")
+def test_workflow_get_item_submissions_from_synced_batch_new(mock_s3client_files_iter):
+    mock_s3client_files_iter.return_value = [
+        "tests/fixtures/digitized-theses/batch-aaa/new-theses/05588126/05588126.xml"
+    ]
+    workflow = DigitizedTheses(batch_id="batch-aaa")
+    results = workflow._get_item_submissions_from_synced_batch()
+
+    assert results == [
+        ItemSubmission(
+            batch_id="batch-aaa",
+            item_identifier="05588126",
+            workflow_name="digitized-theses",
+            dspace_handle=None,
+            status=ItemSubmissionStatus.CREATE_SUCCESS,
+            status_details="New thesis",
+        )
+    ]
+
+
+@patch("dsc.workflows.digitized_theses.workflow.S3Client.files_iter")
+def test_workflow_get_item_submissions_from_synced_batch_skipped(
+    mock_s3client_files_iter,
+):
+    mock_s3client_files_iter.return_value = [
+        "tests/fixtures/digitized-theses/batch-aaa/skipped-theses/05588126/05588126.xml"
+    ]
+    workflow = DigitizedTheses(batch_id="batch-aaa")
+    results = workflow._get_item_submissions_from_synced_batch()
+
+    assert results == [
+        ItemSubmission(
+            batch_id="batch-aaa",
+            item_identifier="05588126",
+            workflow_name="digitized-theses",
+            dspace_handle=None,
+            status=ItemSubmissionStatus.CREATE_SKIPPED,
+            status_details="Skipped thesis",
+        )
+    ]
 
 
 @patch("dsc.workflows.digitized_theses.workflow.requests")
@@ -371,7 +469,7 @@ def test_workflow_submit_items_handles_errors(
     )
 
 
-def test_workflow_load_batch_manifest(mock_s3_digitized_theses):
+def test_workflow_load_batch_manifest(mock_s3_digitized_theses_dsc):
     workflow = DigitizedTheses(batch_id="batch-aaa")
     assert workflow._load_batch_manifest() == defaultdict(
         dict,
@@ -385,7 +483,7 @@ def test_workflow_load_batch_manifest(mock_s3_digitized_theses):
 
 
 @freeze_time("2025-01-01 09:00:00")
-def test_workflow_get_transformed_metadata(mock_s3_digitized_theses):
+def test_workflow_get_transformed_metadata(mock_s3_digitized_theses_dsc):
     workflow = DigitizedTheses(batch_id="batch-aaa")
     item_metadata = workflow._get_transformed_metadata(
         source_metadata_file="tests/fixtures/digitized-theses/batch-aaa/replacement-theses/05588126/05588126.xml"


### PR DESCRIPTION
### Purpose and background context
This PR updates the digitized theses workflow to retrieve item handles for replacement theses during the batch creation process when `synced=True` (i.e., the batch folder was synced from the DSC S3 bucket in Stage to the DSC S3 bucket in Prod). 

As shown in [`DigitizedTheses.prepare_batch`](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1756-digitized-theses-synced-batches/dsc/workflows/digitized_theses/workflow.py#L139-L156), when `synced=True`, the workflow derives a list of `ItemSubmissions` based on the contents of the batch folder synced to `S3_BUCKET_SUBMISSION_ASSETS` rather than repeating the steps outlined in [`DigitizedTheses._create_batch_in_s3`](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1756-digitized-theses-synced-batches/dsc/workflows/digitized_theses/workflow.py#L225-L321). Effectively, this means:

* Skipping the step that syncs the batch from the _workspace_ S3 bucket into DSC
* Skipping downloading of metadata from Alma
* Skipping checks via DSpace client to determine new, replacement, or skipped theses

When the batch was previously prepared and `synced=True`, all this information can be derived from the contents of the batch folder (e.g., the thesis type is determined by the subfolder the item submission is located in `dsc-upload/digitized-theses/batch/<thesis-type>/`). 

_However,_ as noted in [this Copilot review](https://github.com/MITLibraries/dspace-submission-composer/pull/241#discussion_r3318728914), `DigitizedTheses._get_item_submissions_from_synced_batch` was missing a step to retrieve the handle for a DSpace item in the case of a **replacement thesis**.  This PR [adds a new code block](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1756-digitized-theses-synced-batches/dsc/workflows/digitized_theses/workflow.py#L203-L214), which requires using a DSpace client to retrieve the `Item` object from DSpace and extract the `handle` attribute.

**Notes:**
* Also updated the method to [create an instance of `ItemSubmission` at the beginning](https://github.com/MITLibraries/dspace-submission-composer/blob/IN-1756-digitized-theses-synced-batches/dsc/workflows/digitized_theses/workflow.py#L195-L200) so that the method can directly assign attributes to the instance.

### How can a reviewer manually see the effects of these changes?
Review [the added unit test](https://github.com/MITLibraries/dspace-submission-composer/pull/244/changes#diff-2b34f3f7b9c6e04a94bf0855eb0a73c239e54098f467b2d3fb1f9c5a243a87a7R176-R204).

**Note:** While it was straightforward to add a unit test for the `synced=True` path, creating unit tests for `synced=False` path (i.e., [`DigitizedTheses._create_batch_in_s3`](https://github.com/MITLibraries/dspace-submission-composer/blob/main/dsc/workflows/digitized_theses/workflow.py#L208-L305)) is harder given all the steps involved. That said, there are unit tests for the smaller sub-methods it relies on + [previous testing with MinIO demonstrates the code works as expected](https://github.com/MITLibraries/dspace-submission-composer/pull/240).  Just continuing to share with reviewers that improving/adding unit tests continue to be on my mind!

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1756

### Code review
* Code review best practices are documented [here](https://mitlibraries.github.io/guides/collaboration/code_review.html) and you are encouraged to have a constructive dialogue with your reviewers about their preferences and expectations.