### PR TITLE
Digitized theses report updates

### DIFF
--- a/dsc/db/models.py
+++ b/dsc/db/models.py
@@ -1,6 +1,5 @@
 import logging
 from enum import StrEnum
-from typing import TypedDict
 
 from pynamodb.attributes import (
     JSONAttribute,
@@ -20,6 +19,11 @@ ITEM_SUBMISSION_LOG_STR = (
 )
 
 
+class ItemSubmissionOperation(StrEnum):
+    CREATE = "create"
+    UPDATE = "update"
+
+
 class ItemSubmissionStatus(StrEnum):
     CREATE_SUCCESS = "create_success"
     CREATE_FAILED = "create_failed"
@@ -30,19 +34,6 @@ class ItemSubmissionStatus(StrEnum):
     INGEST_FAILED = "ingest_failed"
     INGEST_UNKNOWN = "ingest_unknown"
     MAX_RETRIES_REACHED = "max_retries_reached"
-
-
-class OptionalItemAttributes(TypedDict, total=False):
-    source_system_identifier: str
-    collection_handle: str
-    dspace_handle: str
-    status: str
-    status_details: str
-    ingest_date: str
-    last_result_message: str
-    last_run_date: str
-    submit_attempts: int
-    ingest_attempts: int
 
 
 class ItemSubmissionDB(Model):
@@ -68,6 +59,7 @@ class ItemSubmissionDB(Model):
             an item is successfully ingested into DSpace.
             NOTE: If the item is sent to a DSpace submission queue, the handle is
             NOT provided.
+        operation: item operation to perform [create, update]. Defaults to None.
         status: The current state of an item submission in the DSC workflow.
             See dsc.db.models.ItemSubmissionStatus for accepted values.
         status_details: Additional details regarding the status of an item
@@ -96,6 +88,7 @@ class ItemSubmissionDB(Model):
     source_system_identifier = UnicodeAttribute(null=True)
     collection_handle = UnicodeAttribute(null=True)
     dspace_handle = UnicodeAttribute(null=True)
+    operation = UnicodeAttribute(null=True)
     status = UnicodeAttribute(null=True)
     status_details = UnicodeAttribute(null=True)
     ingest_date = UTCDateTimeAttribute(null=True)

--- a/dsc/item_submission.py
+++ b/dsc/item_submission.py
@@ -57,6 +57,7 @@ class ItemSubmission:
     ingest_date: str | None = None
     last_result_message: str | None = None
     dspace_handle: str | None = None
+    operation: Literal["create", "update"] | None = None
     status: str | None = None
     status_details: str | None = None
 

--- a/dsc/reports/base.py
+++ b/dsc/reports/base.py
@@ -135,6 +135,7 @@ class Report(ABC):
                 "batch_id",
                 "item_identifier",
                 "source_system_identifier",
+                "operation",
                 "status",
                 "status_details",
                 "dspace_handle",

--- a/dsc/reports/digitized_theses.py
+++ b/dsc/reports/digitized_theses.py
@@ -3,7 +3,7 @@ from io import BytesIO, StringIO
 import pandas as pd
 from lxml import etree
 
-from dsc.db.models import ItemSubmissionStatus
+from dsc.db.models import ItemSubmissionOperation, ItemSubmissionStatus
 from dsc.reports.base import Attachment, FinalizeReport
 
 
@@ -30,6 +30,7 @@ class DigitizedThesesFinalizeReport(FinalizeReport):
             item_submission.asdict(attrs=fields)
             for item_submission in self.get_item_submissions()
             if item_submission.status == ItemSubmissionStatus.INGEST_SUCCESS
+            and item_submission.operation == ItemSubmissionOperation.CREATE
         ]
         pd.DataFrame(item_submission_dicts).to_csv(
             buffer, sep="\t", header=False, index=False
@@ -48,6 +49,7 @@ class DigitizedThesesFinalizeReport(FinalizeReport):
             item_submission.asdict(attrs=fields)
             for item_submission in self.get_item_submissions()
             if item_submission.status == ItemSubmissionStatus.INGEST_SUCCESS
+            and item_submission.operation == ItemSubmissionOperation.CREATE
         ]
 
         root = etree.Element("collection")
@@ -56,7 +58,7 @@ class DigitizedThesesFinalizeReport(FinalizeReport):
 
             # write OCoLC (item identifier) to MARC 035 $a
             system_control_number = self._create_datafield_element(
-                text=item_submission["item_identifier"],
+                text=f"(OCoLC){item_submission['item_identifier']}",
                 tag="035",
                 subfield_code="a",
                 ind1=" ",

--- a/dsc/workflows/digitized_theses/workflow.py
+++ b/dsc/workflows/digitized_theses/workflow.py
@@ -204,12 +204,14 @@ class DigitizedTheses(Workflow):
                         item_submission.item_identifier
                     )
                     item_submission.dspace_handle = dspace_item.handle
+                    item_submission.operation = "update"
                     item_submission.status = ItemSubmissionStatus.CREATE_SUCCESS
                     item_submission.status_details = "Replacement thesis"
                 except exceptions.DSpaceClientSearchError as exception:
                     item_submission.status = ItemSubmissionStatus.CREATE_SKIPPED
                     item_submission.status_details = str(exception)
             elif theses_subfolder == "new-theses":
+                item_submission.operation = "create"
                 item_submission.status = ItemSubmissionStatus.CREATE_SUCCESS
                 item_submission.status_details = "New thesis"
             else:
@@ -294,9 +296,11 @@ class DigitizedTheses(Workflow):
 
             if dspace_item and self._is_replacement_thesis(dspace_item):
                 item_submission.dspace_handle = dspace_item.handle
+                item_submission.operation = "update"
                 item_submission.status = ItemSubmissionStatus.CREATE_SUCCESS
                 item_submission.status_details = "Replacement thesis"
             else:
+                item_submission.operation = "create"
                 item_submission.status = ItemSubmissionStatus.CREATE_SUCCESS
                 item_submission.status_details = "New thesis"
             item_submissions.append(item_submission)
@@ -529,15 +533,12 @@ class DigitizedTheses(Workflow):
                 ]["bitstream_files"]
 
                 # send submission message based on thesis type
-                if (
-                    manifest[item_submission.item_identifier]["thesis_type"]
-                    == "Replacement thesis"
-                ):
+                if item_submission.operation == "update":
                     response = item_submission.send_submission_message(
                         submission_source=self.workflow_name,
                         output_queue=self.output_queue,
                         submission_system=self.submission_system,
-                        operation="update",
+                        operation=item_submission.operation,
                         item_handle=item_submission.dspace_handle,
                     )
                 else:

--- a/tests/workflows/digitized_theses/test_workflow.py
+++ b/tests/workflows/digitized_theses/test_workflow.py
@@ -198,6 +198,7 @@ def test_workflow_get_item_submissions_from_synced_batch_replacement(
             item_identifier="05588126",
             workflow_name="digitized-theses",
             dspace_handle="1721.1/157651",
+            operation="update",
             status=ItemSubmissionStatus.CREATE_SUCCESS,
             status_details="Replacement thesis",
         )
@@ -241,6 +242,7 @@ def test_workflow_get_item_submissions_from_synced_batch_new(mock_s3client_files
             item_identifier="05588126",
             workflow_name="digitized-theses",
             dspace_handle=None,
+            operation="create",
             status=ItemSubmissionStatus.CREATE_SUCCESS,
             status_details="New thesis",
         )


### PR DESCRIPTION
### Purpose and background context
Received change requests for users of the digitized theses workflow, specifically: (1) a field to indicate 'new' vs 'replacement' theses [since 'status' changes with each DSO step performed], (2) inclusion of '(OCoLC)' prefix for MARC 035 $a value in Alma XML export, and (3) filter item submissions in exports to 'new theses'.

### How can a reviewer manually see the effects of these changes?
See [comment in INFRA-639](https://mitlibraries.atlassian.net/browse/INFRA-639?focusedCommentId=195484), showing results from latest test run!

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
* https://mitlibraries.atlassian.net/browse/IN-1782

### Code review
* Code review best practices are documented [here](https://mitlibraries.github.io/guides/collaboration/code_review.html) and you are encouraged to have a constructive dialogue with your reviewers about their preferences and expectations.