### PR TITLE
The 'sync' CLI command only raises an exception with non-zero return …

### DIFF
--- a/dsc/cli.py
+++ b/dsc/cli.py
@@ -216,7 +216,9 @@ def sync(
     return_code = run_aws_cli_sync(
         source, destination, exclude_patterns=["dspace_metadata/*"], dry_run=dry_run
     )
-    ctx.exit(return_code)
+
+    if return_code != 0:
+        ctx.exit(return_code)
 
 
 @main.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -388,6 +388,59 @@ def test_sync_use_source_and_destination_success(
     )
 
 
+@patch("dsc.cli.run_aws_cli_sync")
+def test_sync_failure_raises_system_exit(
+    mock_run_aws_cli_sync, caplog, runner, monkeypatch, moto_server, config_instance
+):
+    """Run sync using moto stand-alone server."""
+    caplog.set_level("DEBUG")
+    monkeypatch.setenv("S3_BUCKET_SUBMISSION_ASSETS", "destination")
+    monkeypatch.setenv("AWS_ENDPOINT_URL", moto_server)
+
+    # set fake AWS credentials
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+    # raise error code 1
+    mock_run_aws_cli_sync.return_value = 1
+
+    # point boto3 client to test server
+    s3 = boto3.client(
+        "s3", region_name=config_instance.aws_region_name, endpoint_url=moto_server
+    )
+
+    # create 'source' bucket for syncing
+    s3.create_bucket(Bucket="source")
+    s3.put_object(
+        Bucket="source",
+        Key="test/batch-aaa/123.zip",
+        Body=b"",
+    )
+
+    # create 'destination' bucket
+    s3.create_bucket(Bucket="destination")
+
+    result = runner.invoke(
+        main,
+        [
+            "--verbose",
+            "--workflow-name",
+            "test",
+            "--batch-id",
+            "batch-aaa",
+            "sync",
+            "--source",
+            "s3://source/test/batch-aaa",
+            "--destination",
+            "s3://destination/test/batch-aaa",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, SystemExit)
+
+
 def test_sync_bad_usage_raise_error(
     caplog, runner, monkeypatch, moto_server, config_instance
 ):


### PR DESCRIPTION
### Purpose and background context
Fix bug: When the `sync` CLI command calls utils.aws.s3.run_awas_cli_sync helper method it should only exit (i.e., raise click.exceptions.Exit) with non-zero return codes.

### How can a reviewer manually see the effects of these changes?
Review [added unit test](https://github.com/MITLibraries/dspace-submission-composer/pull/254/changes#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR391-R441).

**Note:** The unit test checks whether the result from the `sync` CLI command would raise a `SystemExit` exception [instead of a `click.exceptions.Exit` exception](https://github.com/MITLibraries/dspace-submission-composer/blob/INFRA-649-fix-bug-in-sync-command/dsc/cli.py#L130) when it [calls `ctx.exit()` on non-zero return codes from `run_aws_cli_sync()` helper method](https://github.com/MITLibraries/dspace-submission-composer/blob/INFRA-649-fix-bug-in-sync-command/dsc/cli.py#L220-L221). This is because our unit tests invoke the CLI using the `CliRunner` from `click`. In practice, it would raise a `click.exceptions.Exit`.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
* https://mitlibraries.atlassian.net/browse/INFRA-649

### Code review
* Code review best practices are documented [here](https://mitlibraries.github.io/guides/collaboration/code_review.html) and you are encouraged to have a constructive dialogue with your reviewers about their preferences and expectations.